### PR TITLE
Gasp emote fix

### DIFF
--- a/Resources/Prototypes/_CE/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_CE/Entities/Mobs/Species/base.yml
@@ -207,7 +207,7 @@
   - MobFlammable
   - CEMobStarving
   - CEBaseMobSpecies
-  - MobRespirator
+  - CEMobRespirator
   id: CEBaseMobSpeciesOrganic
   save: false
   abstract: true

--- a/Resources/Prototypes/_CE/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/_CE/Entities/Mobs/base.yml
@@ -74,6 +74,20 @@
         Bloodloss: 0.25
   - type: Thirst
 
+# Used for mobs that need to breathe
+- type: entity
+  save: false
+  id: CEMobRespirator
+  abstract: true
+  components:
+  - type: Respirator
+    damage:
+      types:
+        Asphyxiation: 2
+    damageRecovery:
+      types:
+        Asphyxiation: -1.0
+
 - type: entity
   id: CEMobMagical
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fix emotions Gasp. Now it works even in critical state.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/crystallpunk-14/crystall-edge/issues/166
## Technical details
<!-- Summary of code changes for easier review. -->
Added parent `MobRespirator` to the main entity of the doll `CEBaseMobSpeciesOrganic`, as it is required in the whitelist for such emotions.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
[bandicam 2025-12-23 10-09-00-093.webm](https://github.com/user-attachments/assets/cce42c17-16ab-496d-ad45-768d79c0bfd8)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Fixed the gasp emote in critical states.