### PR TITLE
fixed:  sprite component mixing with wrong owner entity

### DIFF
--- a/Content.Client/_CE/ZLevels/Flight/CEClientZFlightSystem.cs
+++ b/Content.Client/_CE/ZLevels/Flight/CEClientZFlightSystem.cs
@@ -28,7 +28,7 @@ public sealed class CEClientZFlightSystem : CESharedZFlightSystem
 
             var vfx = SpawnAtPosition(flyer.FlightVfx, xform.Coordinates);
 
-            _sprite.SetOffset((vfx, sprite), new Vector2(0, zPhys.LocalPosition * CEClientZLevelsSystem.ZLevelOffset) + zPhys.SpriteOffsetDefault);
+            _sprite.SetOffset(vfx, new Vector2(0, zPhys.LocalPosition * CEClientZLevelsSystem.ZLevelOffset) + zPhys.SpriteOffsetDefault);
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
removed sprite component from hoverboard entity that was mixed with the sfx entity. 

fixes: #239 
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
## Media 
Before: <img width="703" height="198" alt="image" src="https://github.com/user-attachments/assets/e7e23c0b-a8cc-471b-9742-aa81e4b68f50" />
After: <img width="469" height="114" alt="image" src="https://github.com/user-attachments/assets/4caaa3b4-f34c-4e7c-b7df-60d1214f2c94" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--

