### PR TITLE
Higher zlevels rendering (experiment)

### DIFF
--- a/Content.Client/_CE/ZLevels/Core/ScalingViewport.CEZLevels.cs
+++ b/Content.Client/_CE/ZLevels/Core/ScalingViewport.CEZLevels.cs
@@ -116,7 +116,10 @@ public sealed partial class ScalingViewport
         if (playerXform.MapUid is null)
             return;
 
-        var lookUp = zLevelViewer.LookUp ? 1 : 0;
+        // Calculate visible z-levels above based on whether LookUp is enabled and ceiling visibility
+        var lookUp = 0;
+        if (zLevelViewer.LookUp)
+            lookUp = _zLevels.GetVisibleZLevelsAbove(_player.LocalEntity.Value, playerXform.MapUid);
 
         var lowestDepth = 0;
         for (var i = 0; i >= -CESharedZLevelsSystem.MaxZLevelsBelowRendering; i--)

--- a/Content.Server/_CE/ZLevels/Core/CEZLevelsSystem.View.cs
+++ b/Content.Server/_CE/ZLevels/Core/CEZLevelsSystem.View.cs
@@ -121,10 +121,13 @@ public sealed partial class CEZLevelsSystem
             eyes.Add(newEye);
         }
 
-        // We constantly load the upper z-level for the client so that you can quickly look up and climb stairs without PVS lag.
-        if (TryMapUp(map.Value, out var aboveMapUid))
+        // We constantly load the upper z-levels for the client so that you can quickly look up and climb stairs without PVS lag.
+        for (var i = 1; i <= MaxZLevelsAboveRendering; i++)
         {
-            var newEye = SpawnAtPosition(_zEyeProto, new EntityCoordinates(aboveMapUid.Value, globalPos));
+            if (!TryMapOffset(map.Value, i, out var mapUidAbove))
+                break;
+
+            var newEye = SpawnAtPosition(_zEyeProto, new EntityCoordinates(mapUidAbove.Value, globalPos));
 
             Transform(newEye).GridTraversal = false;
             _viewSubscriber.AddViewSubscriber(newEye, actor.PlayerSession);

--- a/Content.Shared/_CE/ZLevels/Core/EntitySystems/CESharedZLevelsSystem.Movement.cs
+++ b/Content.Shared/_CE/ZLevels/Core/EntitySystems/CESharedZLevelsSystem.Movement.cs
@@ -20,8 +20,6 @@ namespace Content.Shared._CE.ZLevels.Core.EntitySystems;
 
 public abstract partial class CESharedZLevelsSystem
 {
-    public const int MaxZLevelsBelowRendering = 3;
-
     private const float ZGravityForce = 9.8f;
     private const float ZVelocityLimit = 20.0f;
 

--- a/Content.Shared/_CE/ZLevels/Core/EntitySystems/CESharedZLevelsSystem.View.cs
+++ b/Content.Shared/_CE/ZLevels/Core/EntitySystems/CESharedZLevelsSystem.View.cs
@@ -12,23 +12,13 @@ namespace Content.Shared._CE.ZLevels.Core.EntitySystems;
 
 public abstract partial class CESharedZLevelsSystem
 {
+    public const int MaxZLevelsBelowRendering = 3;
+    public const int MaxZLevelsAboveRendering = 3;
+
     [Dependency] protected readonly ITileDefinitionManager TilDefMan = default!;
     private void InitView()
     {
-        SubscribeLocalEvent<CEZLevelViewerComponent, MoveEvent>(OnViewerMove);
         SubscribeLocalEvent<CEZLevelViewerComponent, CEToggleZLevelLookUpAction>(OnToggleLookUp);
-    }
-
-    protected virtual void OnViewerMove(Entity<CEZLevelViewerComponent> ent, ref MoveEvent args)
-    {
-        if (!ent.Comp.LookUp)
-            return;
-
-        if (!HasOpaqueAbove(ent))
-            return;
-
-        ent.Comp.LookUp = false;
-        DirtyField(ent, ent.Comp, nameof(CEZLevelViewerComponent.LookUp));
     }
 
     private void OnToggleLookUp(Entity<CEZLevelViewerComponent> ent, ref CEToggleZLevelLookUpAction args)
@@ -38,35 +28,46 @@ public abstract partial class CESharedZLevelsSystem
 
         args.Handled = true;
 
-        if (HasOpaqueAbove(ent))
-        {
-            _popup.PopupClient(Loc.GetString("ce-zlevel-look-up-fail"), ent, ent);
-            return;
-        }
-
         ent.Comp.LookUp = !ent.Comp.LookUp;
         DirtyField(ent, ent.Comp, nameof(CEZLevelViewerComponent.LookUp));
     }
 
-    public bool HasOpaqueAbove(EntityUid ent, Entity<CEZLevelMapComponent?>? currentMapUid = null)
+    /// <summary>
+    /// Calculates the maximum number of z-levels above that are visible from the entity's current position.
+    /// Stops when an opaque tile is encountered.
+    /// </summary>
+    public int GetVisibleZLevelsAbove(EntityUid ent, Entity<CEZLevelMapComponent?>? currentMapUid = null)
     {
         currentMapUid ??= Transform(ent).MapUid;
 
         if (currentMapUid is null)
-            return false;
+            return 0;
 
-        if (!TryMapUp(currentMapUid.Value, out var mapAboveUid))
-            return false;
+        var visibleLevels = 0;
+        var checkMapUid = currentMapUid.Value.Owner;
 
-        if (!_gridQuery.TryComp(mapAboveUid.Value, out var mapAboveGrid))
-            return false;
+        for (var i = 1; i <= MaxZLevelsAboveRendering; i++)
+        {
+            if (!TryMapUp(checkMapUid, out var mapAboveUid))
+                break;
 
-        if (!_map.TryGetTileRef(mapAboveUid.Value, mapAboveGrid, _transform.GetWorldPosition(ent), out var tileRef))
-            return false;
+            checkMapUid = mapAboveUid.Value.Owner;
 
-        var tileDef = (ContentTileDefinition)TilDefMan[tileRef.Tile.TypeId];
+            if (!_gridQuery.TryComp(mapAboveUid.Value, out var mapAboveGrid))
+                break;
 
-        return !tileDef.Transparent;
+            if (!_map.TryGetTileRef(mapAboveUid.Value, mapAboveGrid, _transform.GetWorldPosition(ent), out var tileRef))
+                break;
+
+            var tileDef = (ContentTileDefinition)TilDefMan[tileRef.Tile.TypeId];
+
+            if (!tileDef.Transparent)
+                break;
+
+            visibleLevels++;
+        }
+
+        return visibleLevels;
     }
 }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Now players can look up to 3 levels when raising their heads, limited only by the ceiling.

Alternative to #62 
for testing purposes, according to the discussion: https://discord.com/channels/1221923073759121468/1460204318534664284

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/83bf5d99-249c-4836-b500-e38b53319dc4

https://github.com/user-attachments/assets/47210191-3c70-4188-b709-3b565770dcf9

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Now players can look up to 3 levels when raising their heads, limited only by the ceiling.
