### PR TITLE
fixed keybind for skilltree

### DIFF
--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -87,7 +87,7 @@ binds:
   key: NumpadNum5
 # Misc
 # CrystallEdge Zone
-- function: CP14OpenSkillMenu
+- function: OpenSkillMenu
   type: State
   key: R
 - function: OpenBelt2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
the keybind had the wrong function name. i changed it and now R is the default key for opening the skill tree again
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix
## Technical details
<!-- Summary of code changes for easier review. -->
changed CP14OpenSkillMenu to OpenSkillMenu in keybind.yml
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Skilltree menu now has R as default keybind as was intended