### PR TITLE
No vanilla entities in CrystallEdge

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -272,12 +272,12 @@ namespace Content.IntegrationTests.Tests
         }
 
         /// <summary>
-        /// CrystallEdge - we ensuring that maps doesnt have any vanilla entities
+        /// CrystallEdge - we ensure that maps don't have any vanilla entities
         /// </summary>
         private void CECheckOnlyForkFiltered(ResPath map, YamlNode node, IPrototypeManager protoManager)
         {
             //ignore all vanilla maps
-            if (!map.ToString().StartsWith("CE"))
+            if (!map.ToString().Contains("_CE"))
                 return;
 
             var yamlEntities = node["entities"];

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -222,6 +222,7 @@ namespace Content.IntegrationTests.Tests
                 // TODO MAP TESTS
                 // Move this to some separate test?
                 CheckDoNotMap(map, root, protoManager);
+                CECheckOnlyForkFiltered(map, root, protoManager); //CrystallEdge
 
                 if (version >= 7)
                 {
@@ -268,6 +269,35 @@ namespace Content.IntegrationTests.Tests
                 return false;
 
             return allowedProtos.Contains(protoId);
+        }
+
+        /// <summary>
+        /// CrystallEdge - we ensuring that maps doesnt have any vanilla entities
+        /// </summary>
+        private void CECheckOnlyForkFiltered(ResPath map, YamlNode node, IPrototypeManager protoManager)
+        {
+            //ignore all vanilla maps
+            if (!map.ToString().StartsWith("CE"))
+                return;
+
+            var yamlEntities = node["entities"];
+            if (!protoManager.TryIndex<EntityCategoryPrototype>("ForkFiltered", out var filterCategory))
+                return;
+
+            Assert.Multiple(() =>
+            {
+                foreach (var yamlEntity in (YamlSequenceNode)yamlEntities)
+                {
+                    var protoId = yamlEntity["proto"].AsString();
+
+                    // This doesn't properly handle prototype migrations, but thats not a significant issue.
+                    if (!protoManager.TryIndex(protoId, out var proto, false))
+                        continue;
+
+                    Assert.That(proto.Categories.Contains(filterCategory),
+                        $"\nMap {map} contains entities without FORK FILTERED category ({proto.Name})");
+                }
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A small injection has been added to PostMapInitTest, which validates that no vanilla entities are mapped on CrystallEdge maps.

fix #72