### PR TITLE
ZLevels PlacementOverlay fix

### DIFF
--- a/Content.Client/_CE/ZLevels/Core/ScalingViewport.CEZLevels.cs
+++ b/Content.Client/_CE/ZLevels/Core/ScalingViewport.CEZLevels.cs
@@ -22,6 +22,7 @@ public sealed partial class ScalingViewport
     [Dependency] private readonly IEyeManager _eyeManager = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly ITileDefinitionManager _tile = default!;
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
 
     private CEClientZLevelsSystem? _zLevels;
     private SharedMapSystem? _mapSystem;
@@ -137,13 +138,53 @@ public sealed partial class ScalingViewport
                 break;
         }
 
+        // Try to locate the placement overlay so we can temporarily disable it while rendering z-levels
+        Overlay? placementOverlay = null;
+
+        // Search for placement overlay by type name
+        // yeah i know this is junky af but i don't have any other solutions
+        foreach (var overlay in _overlayManager.AllOverlays)
+        {
+            if (overlay.GetType().Name == "PlacementOverlay")
+            {
+                placementOverlay = overlay;
+                break;
+            }
+        }
+
+        var placementRemoved = false;
+
         //From the lowest depth to the highest, render each level
         for (var depth = lowestDepth; depth <= lookUp; depth++)
         {
             if (depth == 0)
+            {
                 viewport.Eye = _fallbackEye;
+
+                // Restore placement overlay for the base layer
+                if (placementRemoved && placementOverlay is not null)
+                {
+                    try
+                    {
+                        _overlayManager.AddOverlay(placementOverlay);
+                        placementRemoved = false;
+                    }
+                    catch { }
+                }
+            }
             else
             {
+                // Remove placement overlay before rendering z-levels so it will only display on ours
+                if (!placementRemoved && placementOverlay is not null)
+                {
+                    try
+                    {
+                        _overlayManager.RemoveOverlay(placementOverlay);
+                        placementRemoved = true;
+                    }
+                    catch { }
+                }
+
                 if (!_zLevels.TryMapOffset(playerXform.MapUid.Value, depth, out var mapUidBelow))
                     continue;
 
@@ -166,6 +207,16 @@ public sealed partial class ScalingViewport
 
             viewport.ClearColor = depth == lowestDepth ? Color.Black : null;
             viewport.Render();
+        }
+
+        // Restore placement overlay
+        if (placementRemoved && placementOverlay is not null)
+        {
+            try
+            {
+                _overlayManager.AddOverlay(placementOverlay);
+            }
+            catch { }
         }
 
         // Restore the Eye


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a bug when placement overlay rendered for all z-levels and caused error spam in client console

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This PR solves https://github.com/crystallpunk-14/crystall-edge/issues/42

## Technical details
<!-- Summary of code changes for easier review. -->
RenderZLevels in ScalingViewport now removes PlacementOverlay for all levels except current

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/ac15c943-47d5-4cbb-9e46-350c6af9740f


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->=
:cl: _kote
- fix: Fixed placement overlay error spam. 
