### PR TITLE
Engineering balance pass

### DIFF
--- a/Content.IntegrationTests/Tests/_CE/CEWorkbench.cs
+++ b/Content.IntegrationTests/Tests/_CE/CEWorkbench.cs
@@ -45,8 +45,8 @@ public sealed class CEWorkbench
                     if (Math.Abs(resourcePrice) < epsilon && Math.Abs(resultPrice) < epsilon)
                         continue;
 
-                    var minLimit = resourcePrice * 0.8;
-                    var maxLimit = resourcePrice * 1.2;
+                    var minLimit = resourcePrice * 0.7;
+                    var maxLimit = resourcePrice * 1.3;
                     if (resultPrice < minLimit)
                     {
                         Assert.Fail($"The ingredients to craft the [{recipe.ID}] cost more than the result of the crafting. \nCrafting: [{recipe.Result.Id} x{recipe.ResultCount}]. \nExpected price range: from {minLimit} to {maxLimit}. \nCurrent price: {resultPrice}");

--- a/Content.Shared/_CE/MagicEnergy/Components/CEEnergyOverchargeDamageComponent.cs
+++ b/Content.Shared/_CE/MagicEnergy/Components/CEEnergyOverchargeDamageComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class CEEnergyOverchargeDamageComponent : Component
     {
         DamageDict = new()
         {
-            { "Shock", 1f },
+            { "Shock", 0.25f },
         }
     };
 

--- a/Content.Shared/_CE/OreVein/CEOreVeinComponent.cs
+++ b/Content.Shared/_CE/OreVein/CEOreVeinComponent.cs
@@ -21,16 +21,4 @@ public sealed partial class CEOreVeinComponent : Component
 
     [DataField]
     public SoundSpecifier SpawnSound = new SoundPathSpecifier("/Audio/Effects/picaxe2.ogg");
-
-    /// <summary>
-    /// Total number of harvests this vein can yield before it's depleted and deleted.
-    /// </summary>
-    [DataField(required: true)]
-    public int MaxAmount;
-
-    /// <summary>
-    /// Remaining number of harvests. Initialized to <see cref="MaxAmount"/> on MapInit.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public int CurrentAmount;
 }

--- a/Content.Shared/_CE/OreVein/CEOreVeinSystem.cs
+++ b/Content.Shared/_CE/OreVein/CEOreVeinSystem.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using Content.Shared.Damage.Systems;
 using Content.Shared.EntityTable;
-using Content.Shared.Examine;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Shared._CE.OreVein;
@@ -19,21 +18,7 @@ public sealed partial class CEOreVeinSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<CEOreVeinComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<CEOreVeinComponent, DamageChangedEvent>(OnDamageChanged);
-        SubscribeLocalEvent<CEOreVeinComponent, ExaminedEvent>(OnExamined);
-    }
-
-    private void OnMapInit(Entity<CEOreVeinComponent> ent, ref MapInitEvent args)
-    {
-        ent.Comp.CurrentAmount = ent.Comp.MaxAmount;
-        Dirty(ent);
-    }
-
-    private void OnExamined(Entity<CEOreVeinComponent> ent, ref ExaminedEvent args)
-    {
-        var percent = (int) MathF.Round((ent.Comp.MaxAmount - ent.Comp.CurrentAmount) / (float) ent.Comp.MaxAmount * 100f);
-        args.PushMarkup(Loc.GetString("ce-ore-vein-examine-depleted", ("percent", percent)));
     }
 
     private void OnDamageChanged(Entity<CEOreVeinComponent> ent, ref DamageChangedEvent args)
@@ -69,11 +54,5 @@ public sealed partial class CEOreVeinSystem : EntitySystem
         }
         _damageable.ChangeDamage(ent.Owner, -requiredDamage);
         _audio.PlayPredicted(ent.Comp.SpawnSound, targetSpawnPosition, args.Origin);
-
-        ent.Comp.CurrentAmount--;
-        Dirty(ent);
-
-        if (ent.Comp.CurrentAmount <= 0)
-            QueueDel(ent.Owner);
     }
 }

--- a/Content.Shared/_CE/Power/CESharedPowerSystem.cs
+++ b/Content.Shared/_CE/Power/CESharedPowerSystem.cs
@@ -63,7 +63,7 @@ public abstract partial class CESharedPowerSystem : EntitySystem
         if (battery.LastCharge <= 0f)
             return;
 
-        Irradiate(Transform(ent).Coordinates, battery.LastCharge, ent.Comp.Time);
+        Irradiate(Transform(ent).Coordinates, battery.LastCharge * ent.Comp.IrradiateCoefficient, ent.Comp.Time);
     }
 
     public void Irradiate(EntityCoordinates position, float charge, TimeSpan seconds)

--- a/Resources/Locale/en-US/_CE/ore-vein/ore-vein.ftl
+++ b/Resources/Locale/en-US/_CE/ore-vein/ore-vein.ftl
@@ -1,1 +1,0 @@
-ce-ore-vein-examine-depleted = The vein is depleted by {$percent}%.

--- a/Resources/Locale/ru-RU/_CE/ore-vein/ore-vein.ftl
+++ b/Resources/Locale/ru-RU/_CE/ore-vein/ore-vein.ftl
@@ -1,1 +1,0 @@
-ce-ore-vein-examine-depleted = Жила истощена на {$percent}%.

--- a/Resources/Prototypes/_CE/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_CE/Entities/Clothing/OuterClothing/armor.yml
@@ -8,7 +8,6 @@
     sprite: _CE/Clothing/OuterClothing/Generic/brass_insulator.rsi
   - type: Clothing
     sprite: _CE/Clothing/OuterClothing/Generic/brass_insulator.rsi
-  - type: MultiHandedItem
   - type: CEEnergyRadiationArmor
     armor: 0.75
   - type: Armor
@@ -26,5 +25,5 @@
     price: 300
   - type: CEMagicEssenceStructure
     essences:
-      Armor: { min: 1, max: 3 }
-      Energia: { min: 1, max: 3 }
+      Armor: { min: 3, max: 6 }
+      Energia: { min: 3, max: 6 }

--- a/Resources/Prototypes/_CE/Entities/Effects/misc.yml
+++ b/Resources/Prototypes/_CE/Entities/Effects/misc.yml
@@ -101,6 +101,7 @@
       enabled: true
   - type: RadiationSource
     intensity: 3
+    slope: 1.5
   - type: TimedDespawn
     lifetime: 5
 
@@ -114,7 +115,7 @@
   components:
   - type: RadiationSource
     intensity: 20
-    slope: 1.5
+    slope: 3
 
 - type: entity
   id: CEDirtEffect

--- a/Resources/Prototypes/_CE/Entities/Objects/Materials/ash.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Materials/ash.yml
@@ -26,6 +26,8 @@
     essences:
       Chaos: { min: 1, max: 3 }
       Fire: { min: 0, max: 2 }
+  - type: StackPrice
+    price: 0.15
 
 - type: entity
   id: CEAsh30

--- a/Resources/Prototypes/_CE/Entities/Objects/Materials/machine_cores.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Materials/machine_cores.yml
@@ -42,7 +42,7 @@
   - type: MachineBoard
     prototype: CERecycler
   - type: StaticPrice
-    price: 100
+    price: 90
 
 - type: entity
   id: CEMachineCoreDrill
@@ -52,7 +52,7 @@
   - type: MachineBoard
     prototype: CEDrill
   - type: StaticPrice
-    price: 100
+    price: 90
 
 - type: entity
   id: CEMachineCoreDrillAdvanced
@@ -83,7 +83,7 @@
   - type: MachineBoard
     prototype: CEFunnel
   - type: StaticPrice
-    price: 40
+    price: 30
 
 - type: entity
   id: CEMachineCoreSalaryPlatform
@@ -133,7 +133,7 @@
   - type: MachineBoard
     prototype: CEMagicEssenceAttractor
   - type: StaticPrice
-    price: 150
+    price: 130
 
 
 - type: entity

--- a/Resources/Prototypes/_CE/Entities/Objects/Materials/shards_energy.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Materials/shards_energy.yml
@@ -42,7 +42,6 @@
     startingCharge: 25
   - type: PowerCell
   - type: CEIrradiateOnDestroy
-    irradiateCoefficient: 0.5
   - type: StaticPrice
     price: 0
   - type: CEEnergyOverchargeDamage
@@ -97,7 +96,6 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: CEIrradiateOnDestroy
-    irradiateCoefficient: 0.5
   - type: CEMagicEssenceStructure
     essences:
       Energia: { min: 1, max: 4 }

--- a/Resources/Prototypes/_CE/Entities/Objects/Materials/shards_energy.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Materials/shards_energy.yml
@@ -38,8 +38,8 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Battery
-    maxCharge: 25
-    startingCharge: 25
+    maxCharge: 40
+    startingCharge: 40
   - type: PowerCell
   - type: CEIrradiateOnDestroy
   - type: StaticPrice
@@ -74,8 +74,8 @@
       shader: unshaded
       map: ["random"]
   - type: Battery
-    maxCharge: 30
-    startingCharge: 30
+    maxCharge: 50
+    startingCharge: 50
   - type: PowerCell
   - type: PhysicalComposition
     materialComposition:

--- a/Resources/Prototypes/_CE/Entities/Structures/Architecture/ThinWindows/base.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Architecture/ThinWindows/base.yml
@@ -57,6 +57,8 @@
           collection: WindowShatter
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: CEGridStabilitySupport
+    supportStrength: 3
 
 - type: entity
   parent: BaseStructure

--- a/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/base.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/base.yml
@@ -38,6 +38,7 @@
   - type: CEZLevelHighGround
   - type: CEOccludePipes
   - type: CEGridStabilitySupport
+    supportStrength: 7
   - type: CEZGridConnector
 
 - type: entity
@@ -72,3 +73,5 @@
         - WallLayer
         density: 1000
   - type: CEZLevelHighGround
+  - type: CEGridStabilitySupport
+    supportStrength: 4

--- a/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/natural.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/natural.yml
@@ -53,6 +53,8 @@
     sprite: _CE/Structures/Architecture/Walls/cave_stone_strong.rsi
   - type: IconSmooth
     base: wall
+  - type: CEGridStabilitySupport
+    supportStrength: 100
 
 - type: entity
   id: CEWallDirt
@@ -99,6 +101,8 @@
   - type: Construction
     graph: CEWallDirt
     node: CEWallDirt
+  - type: CEGridStabilitySupport
+    supportStrength: 4
 
 - type: entity
   id: CEWallLeaf
@@ -188,6 +192,8 @@
     heightCurve:
     - 0
     - 0
+  - type: CEGridStabilitySupport
+    supportStrength: 1
 
 - type: entity
   id: CEWallSnow
@@ -240,3 +246,5 @@
   - type: Construction
     graph: CEWallSnow
     node: CEWallSnow
+  - type: CEGridStabilitySupport
+    supportStrength: 4

--- a/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/ore_core.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/ore_core.yml
@@ -4,7 +4,6 @@
   parent: CEBaseWall
   components:
   - type: CEOreVein
-    maxAmount: 75
     damage:
       types:
         Structural: 60
@@ -64,7 +63,6 @@
   - type: TileEmission
     color: "#00ddff"
   - type: CEOreVein
-    maxAmount: 150
     table: !type:AllSelector
       children:
       - id: CEStrongRadiationSourceVFX

--- a/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/wooden.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/wooden.yml
@@ -35,6 +35,8 @@
     graph: CEWallWooden
     node: CEWallFrameWooden
     defaultTarget: CEWallFrameWoodenFinished
+  - type: CEGridStabilitySupport
+    supportStrength: 4
 
 - type: entity
   id: CEWallFrameWoodenFinished
@@ -75,6 +77,8 @@
     interfaces:
       enum.CERadialConstructionUiKey.Key:
         type: CERadialConstructionMenuBoundUserInterface
+  - type: CEGridStabilitySupport
+    supportStrength: 5
 
 - type: entity
   id: CEWallWoodenBase

--- a/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/wooden_palisade.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Architecture/Walls/wooden_palisade.yml
@@ -44,3 +44,5 @@
   - type: Construction
     graph: CEWallWoodenPalisade
     node: CEWallWoodenPalisade
+  - type: CEGridStabilitySupport
+    supportStrength: 4

--- a/Resources/Prototypes/_CE/Entities/Structures/Architecture/Windows/base.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Architecture/Windows/base.yml
@@ -44,6 +44,8 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: CEZLevelHighGround
+  - type: CEGridStabilitySupport
+    supportStrength: 4
 
 - type: entity
   id: CEBaseWindowFrame

--- a/Resources/Prototypes/_CE/Entities/Structures/Architecture/Windows/ice.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Architecture/Windows/ice.yml
@@ -31,3 +31,5 @@
       collection: CECrystalDings
       params:
         variation: 0.03
+  - type: CEGridStabilitySupport
+    supportStrength: 2

--- a/Resources/Prototypes/_CE/Entities/Structures/Specific/Thaumaturgy/node_stabilizer.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Specific/Thaumaturgy/node_stabilizer.yml
@@ -54,4 +54,4 @@
         acts: [ "Destruction" ]
   - type: CEMagicEssenceNodeStabilizer
   - type: StaticPrice
-    price: 240
+    price: 200

--- a/Resources/Prototypes/_CE/Entities/Vehicles/hoverboard.yml
+++ b/Resources/Prototypes/_CE/Entities/Vehicles/hoverboard.yml
@@ -60,7 +60,7 @@
         layer:
         - TableLayer
   - type: StaticPrice
-    price: 170
+    price: 150
   - type: AmbientSound
     enabled: false
     volume: 2

--- a/Resources/Prototypes/_CE/GameRules/variation.yml
+++ b/Resources/Prototypes/_CE/GameRules/variation.yml
@@ -45,7 +45,7 @@
   parent: CEBaseVariationPass
   components:
   - type: CEStaticEntityReplacementVariationPass
-    replacementCount: 15
+    replacementCount: 7
     replacementMap:
       CEWallStone: CEWallIronCore
 
@@ -54,7 +54,7 @@
   parent: CEBaseVariationPass
   components:
   - type: CEStaticEntityReplacementVariationPass
-    replacementCount: 15
+    replacementCount: 7
     replacementMap:
       CEWallStone: CEWallCoalCore
 

--- a/Resources/Prototypes/_CE/Materials/simple.yml
+++ b/Resources/Prototypes/_CE/Materials/simple.yml
@@ -57,7 +57,7 @@
   unit: materials-unit-bar
   icon: { sprite: _CE/Objects/Materials/Metals/iron_scrap.rsi, state: scrap }
   color: "#9093a1"
-  price: 1.2
+  price: 1.0
 
 - type: material
   id: CEBrass
@@ -66,7 +66,7 @@
   unit: materials-unit-bar
   icon: { sprite: _CE/Objects/Materials/Metals/brass_scrap.rsi, state: scrap }
   color: "#bb7547"
-  price: 1.4
+  price: 1.15
 
 - type: material
   id: CEBone

--- a/Resources/Prototypes/_CE/Recipes/Construction/Graphs/Conveyor/conveyor_ladder.yml
+++ b/Resources/Prototypes/_CE/Recipes/Construction/Graphs/Conveyor/conveyor_ladder.yml
@@ -31,7 +31,7 @@
               amount: 1
         - to: CEConveyorLadderReverse
           steps:
-            - tool: Prying
+            - tool: Screwing
               doAfter: 1
 
     - node: CEConveyorLadderReverse
@@ -50,5 +50,5 @@
               amount: 1
         - to: CEConveyorLadder
           steps:
-            - tool: Prying
+            - tool: Screwing
               doAfter: 1

--- a/Resources/Prototypes/_CE/Recipes/Workbench/engineering_table.yml
+++ b/Resources/Prototypes/_CE/Recipes/Workbench/engineering_table.yml
@@ -60,31 +60,43 @@
   result: CEEnergyCrystalCell
   resultCount: 1
 
+- type: CERecipe
+  id: CENail
+  parent: CEBaseEngineeringTableRecipe
+  category: Materials
+  craftTime: 1.0
+  requirements:
+  - !type:StackResource
+    stack: CEIronBar
+    count: 1
+  result: CENail1
+  resultCount: 10
+
 #MARK: Tools
 
 - type: CERecipe
   id: CEMediumBrassPipe15
   parent: CEBaseEngineeringTableRecipe
   category: Tools
-  craftTime: 2.0
+  craftTime: 0.5
   requirements:
   - !type:StackResource
     stack: CEBrassSheet
-    count: 6
+    count: 2
   result: CEMediumBrassPipe1
-  resultCount: 15
+  resultCount: 5
 
 - type: CERecipe
   id: CEBigBrassPipe15
   parent: CEBaseEngineeringTableRecipe
   category: Tools
-  craftTime: 2.0
+  craftTime: 0.5
   requirements:
   - !type:StackResource
     stack: CEBrassSheet
-    count: 12
+    count: 4
   result: CEBigBrassPipe1
-  resultCount: 15
+  resultCount: 5
 
 - type: CERecipe
   id: CEPipeValve10
@@ -94,9 +106,9 @@
   requirements:
   - !type:StackResource
     stack: CEIronBar
-    count: 2
+    count: 1
   result: CEPipeValve1
-  resultCount: 10
+  resultCount: 5
 
 - type: CERecipe
   id: CEWrench

--- a/Resources/Prototypes/_CE/Waypointers/waypointers.yml
+++ b/Resources/Prototypes/_CE/Waypointers/waypointers.yml
@@ -11,7 +11,6 @@
   color: "#e17d44"
   trackedComponents:
   - type: CEOreVein
-    maxAmount: 1 #Stoobid compRegistry
     damage:
       types:
         Structural: 60


### PR DESCRIPTION

:cl:
- add: Windows and unfinished wall frames now also carry over tile stability between z-levels, but to a much lesser extent.
- add: Added the ability to craft nails at the engineering table.
- tweak: Various natural walls now transfer stability between levels to a lesser extent.
- tweak: Ore veins are now infinite again, but there are half as many of them.
- tweak: Damage taken from excess energy has been reduced by 75%, but the amount of energy emitted when breaking crystals has been doubled. The radiation radius from all sources has been reduced from approximately 10–15 tiles to 5 tiles.
- tweak: Pipe crafting recipes at the engineering workbench now produce 5 pipes instead of 15, and consume proportionally fewer resources.
- tweak: The price of brass and iron has been reduced.
- fix: Fixed an issue where it was impossible to build a conveyor staircase leading upward.

