### PR TITLE
Fixes

### DIFF
--- a/Content.Server/_CE/Chemistry/CEDeleteOnEmptySolutionComponent.cs
+++ b/Content.Server/_CE/Chemistry/CEDeleteOnEmptySolutionComponent.cs
@@ -1,0 +1,14 @@
+using Content.Shared.Chemistry.Components;
+
+namespace Content.Server._CE.Chemistry;
+
+/// <summary>
+/// Deletes this entity once the named <see cref="SolutionComponent"/> on it runs out of reagent.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(CEDeleteOnEmptySolutionSystem))]
+public sealed partial class CEDeleteOnEmptySolutionComponent : Component
+{
+    [DataField(required: true)]
+    public string SolutionId = SolutionComponent.DefaultSolutionId;
+}

--- a/Content.Server/_CE/Chemistry/CEDeleteOnEmptySolutionSystem.cs
+++ b/Content.Server/_CE/Chemistry/CEDeleteOnEmptySolutionSystem.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server._CE.Chemistry;
+
+public sealed partial class CEDeleteOnEmptySolutionSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CEDeleteOnEmptySolutionComponent, SolutionChangedEvent>(OnSolutionChanged);
+    }
+
+    private void OnSolutionChanged(Entity<CEDeleteOnEmptySolutionComponent> ent, ref SolutionChangedEvent args)
+    {
+        if (args.Solution.Comp.Id != ent.Comp.SolutionId)
+            return;
+
+        if (args.Solution.Comp.Solution.Volume > FixedPoint2.Zero)
+            return;
+
+        QueueDel(ent.Owner);
+    }
+}

--- a/Content.Server/_CE/MagicEssence/Systems/CEMagicEssenceAttractorSystem.Portable.cs
+++ b/Content.Server/_CE/MagicEssence/Systems/CEMagicEssenceAttractorSystem.Portable.cs
@@ -37,7 +37,7 @@ public sealed partial class CEMagicEssenceAttractorSystem
 
     private void RefreshPortableAttracting(Entity<CEPortableMagicEssenceAttractorComponent> ent, bool folded)
     {
-        var hasCharge = TryComp<BatteryComponent>(ent, out var battery) && battery.LastCharge > 0f;
+        var hasCharge = TryComp<BatteryComponent>(ent, out var battery) && _battery.GetCharge((ent.Owner, battery)) > 0f;
         SetPortableAttracting(ent, !folded && hasCharge);
     }
 
@@ -62,7 +62,7 @@ public sealed partial class CEMagicEssenceAttractorSystem
 
             portable.NextConsumeTime = _timing.CurTime + portable.EnergyConsumeFrequency;
 
-            if (_foldable.IsFolded(uid, foldable) || battery.LastCharge <= 0f)
+            if (_foldable.IsFolded(uid, foldable) || _battery.GetCharge((uid, battery)) <= 0f)
             {
                 SetPortableAttracting(uid, false);
                 continue;

--- a/Content.Shared/_CE/Actions/CESharedActionSystem.Attempt.cs
+++ b/Content.Shared/_CE/Actions/CESharedActionSystem.Attempt.cs
@@ -60,7 +60,7 @@ public abstract partial class CESharedActionSystem
             return;
         }
 
-        if (playerMana.LastCharge < requiredMana)
+        if (_battery.GetCharge((args.User, playerMana)) < requiredMana)
         {
             Popup.PopupClient(Loc.GetString("ce-magic-spell-not-enough-mana"), args.User, args.User);
             args.Cancelled = true;

--- a/Content.Shared/_CE/FlyerBattery/CEZFlyerBatterySystem.cs
+++ b/Content.Shared/_CE/FlyerBattery/CEZFlyerBatterySystem.cs
@@ -33,7 +33,7 @@ public sealed partial class CEZFlyerBatterySystem : EntitySystem
         if (!TryComp<BatteryComponent>(ent, out var battery))
             return;
 
-        if (battery.LastCharge <= 0f)
+        if (_battery.GetCharge((ent.Owner, battery)) <= 0f)
             args.Cancel();
     }
 

--- a/Content.Shared/_CE/Power/CESharedPowerSystem.cs
+++ b/Content.Shared/_CE/Power/CESharedPowerSystem.cs
@@ -60,10 +60,12 @@ public abstract partial class CESharedPowerSystem : EntitySystem
         if (!TryComp<BatteryComponent>(ent, out var battery))
             return;
 
-        if (battery.LastCharge <= 0f)
+        var charge = Battery.GetCharge((ent.Owner, battery));
+
+        if (charge <= 0f)
             return;
 
-        Irradiate(Transform(ent).Coordinates, battery.LastCharge * ent.Comp.IrradiateCoefficient, ent.Comp.Time);
+        Irradiate(Transform(ent).Coordinates, charge * ent.Comp.IrradiateCoefficient, ent.Comp.Time);
     }
 
     public void Irradiate(EntityCoordinates position, float charge, TimeSpan seconds)

--- a/Resources/Prototypes/_CE/Entities/Mobs/GhostRoles/lurker.yml
+++ b/Resources/Prototypes/_CE/Entities/Mobs/GhostRoles/lurker.yml
@@ -178,7 +178,7 @@
     itemIconStyle: BigAction
     sound: !type:SoundPathSpecifier
       path: /Audio/Magic/rumble.ogg
-    useDelay: 3
+    useDelay: 8
     icon:
       sprite: _CE/Actions/lurker.rsi
       state: jump

--- a/Resources/Prototypes/_CE/Entities/Objects/Specific/Thaumaturgy/essence.yml
+++ b/Resources/Prototypes/_CE/Entities/Objects/Specific/Thaumaturgy/essence.yml
@@ -48,6 +48,8 @@
     id: essence
     solution:
       canReact: false
+  - type: CEDeleteOnEmptySolution
+    solutionId: essence
   - type: Visibility
     layer: 16 #magic vision only
   - type: GuideHelp

--- a/Resources/Prototypes/_CE/Entities/Structures/Industrial/lamppost.yml
+++ b/Resources/Prototypes/_CE/Entities/Structures/Industrial/lamppost.yml
@@ -10,6 +10,8 @@
   - type: CEZPhysics
   - type: Transform
     anchored: true
+  - type: Anchorable
+  - type: Pullable
   - type: Clickable
   - type: InteractionOutline
   - type: Sprite


### PR DESCRIPTION

:cl:
- add: Lampposts can now be unanchored and pulled away.
- tweak: The cooldown on the Lurker's jump has been increased from 3 to 7 seconds.
- fix: Flying magical essences now disappear after being absorbed by a magical focus.
- fix: Fixed a bug that caused passive mana regeneration to work only visually and prevented players from casting spells.
