### PR TITLE
Actions/GOAP: проверенный результат выполнения действия

### DIFF
--- a/Content.IntegrationTests/Tests/_CE/CECheckedActionsTest.cs
+++ b/Content.IntegrationTests/Tests/_CE/CECheckedActionsTest.cs
@@ -1,0 +1,282 @@
+using System.Linq;
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._CE.GOAP.Actions;
+using Content.Server._CE.GOAP.Navigation;
+using Content.Server._CE.GOAP.Selectors;
+using Content.Shared._CE.Actions;
+using Content.Shared._CE.GOAP;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Actions.Events;
+using Content.Shared.DoAfter;
+using Content.Shared.Whitelist;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._CE;
+
+[TestFixture]
+public sealed class CECheckedActionsTest : GameTest
+{
+    // Fixture prototypes are loaded per test, outside the global prototype registry.
+    private readonly EntProtoId EntityAction = "CECheckedEntityAction";
+    private readonly EntProtoId WorldAction = "CECheckedWorldAction";
+    private readonly EntProtoId DelayedAction = "CECheckedDelayedAction";
+    private readonly EntProtoId RepeatingAction = "CECheckedRepeatingAction";
+    public override PoolSettings PoolSettings => new() { Connected = false };
+
+    [TestPrototypes]
+    private const string Prototypes = """
+- type: Tag
+  id: CECheckedTarget
+- type: entity
+  id: CECheckedActor
+  components:
+  - type: CECheckedActionProbe
+  - type: Actions
+  - type: DoAfter
+  - type: CEGOAP
+    startSleeping: true
+  - type: CEGOAPTargetBackoff
+    duration: 2
+- type: entity
+  id: CECheckedTarget
+  components:
+  - type: Tag
+    tags: [CECheckedTarget]
+- type: entity
+  id: CECheckedEntityAction
+  parent: BaseAction
+  components:
+  - type: Action
+    checkCanInteract: false
+    checkConsciousness: false
+    useDelay: 0
+  - type: TargetAction
+    range: 1
+    checkCanAccess: false
+  - type: EntityTargetAction
+    event: !type:CECheckedEntityEvent
+- type: entity
+  id: CECheckedWorldAction
+  parent: BaseAction
+  components:
+  - type: Action
+    checkCanInteract: false
+    checkConsciousness: false
+    useDelay: 0
+  - type: TargetAction
+    range: 1
+    checkCanAccess: false
+  - type: WorldTargetAction
+    event: !type:CECheckedWorldEvent
+- type: entity
+  id: CECheckedDelayedAction
+  parent: CECheckedEntityAction
+  components:
+  - type: DoAfterArgs
+    delay: 0.2
+    needHand: false
+    requireCanInteract: false
+- type: entity
+  id: CECheckedRepeatingAction
+  parent: CECheckedDelayedAction
+  components:
+  - type: DoAfterArgs
+    repeat: true
+""";
+
+    [Test]
+    public async Task RejectedEntityAndWorldTargetsDoNotReusePreviousSuccessfulEvent()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var actions = Server.System<SharedActionsSystem>();
+            var actor = SEntMan.SpawnEntity("CECheckedActor", map.GridCoords);
+            var near = SEntMan.SpawnEntity("CECheckedTarget", map.GridCoords.Offset(new Vector2(0.5f, 0)));
+            var far = SEntMan.SpawnEntity("CECheckedTarget", map.GridCoords.Offset(new Vector2(5, 0)));
+            var action = actions.AddAction(actor, EntityAction)!.Value;
+            var probe = SComp<CECheckedActionProbeComponent>(actor);
+            var accepted = new RequestPerformActionEvent(SEntMan.GetNetEntity(action), SEntMan.GetNetEntity(near));
+            var rejected = new RequestPerformActionEvent(SEntMan.GetNetEntity(action), SEntMan.GetNetEntity(far));
+
+            Assert.That(actions.TryPerformActionChecked(accepted, actor), Is.EqualTo(CEActionExecutionResult.Performed));
+            Assert.That(actions.TryPerformActionChecked(rejected, actor), Is.EqualTo(CEActionExecutionResult.InvalidTarget));
+            Assert.That(probe.Calls, Is.EqualTo(1));
+            Assert.That(probe.LastTarget, Is.EqualTo(near));
+
+            SEntMan.DeleteEntity(near);
+            Assert.That(actions.TryPerformActionChecked(accepted, actor), Is.EqualTo(CEActionExecutionResult.InvalidTarget));
+            Assert.That(probe.Calls, Is.EqualTo(1));
+
+            var world = actions.AddAction(actor, WorldAction)!.Value;
+            var nearbyPoint = new RequestPerformActionEvent(SEntMan.GetNetEntity(world), SEntMan.GetNetCoordinates(map.GridCoords));
+            var distantPoint = new RequestPerformActionEvent(SEntMan.GetNetEntity(world), SEntMan.GetNetCoordinates(map.GridCoords.Offset(new Vector2(5, 0))));
+            Assert.That(actions.TryPerformActionChecked(nearbyPoint, actor), Is.EqualTo(CEActionExecutionResult.Performed));
+            Assert.That(actions.TryPerformActionChecked(distantPoint, actor), Is.EqualTo(CEActionExecutionResult.InvalidTarget));
+            var stalePoint = new RequestPerformActionEvent(SEntMan.GetNetEntity(world), new NetCoordinates(NetEntity.Invalid, Vector2.Zero));
+            Assert.That(actions.TryPerformActionChecked(stalePoint, actor), Is.EqualTo(CEActionExecutionResult.InvalidTarget));
+            Assert.That(probe.Calls, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public async Task GoapRejectsFailedTargetButKeepsTargetWhenActorIsUnavailable()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var actions = Server.System<SharedActionsSystem>();
+            var backoff = Server.System<CEGOAPTargetBackoffSystem>();
+            var actor = SEntMan.SpawnEntity("CECheckedActor", map.GridCoords);
+            var target = SEntMan.SpawnEntity("CECheckedTarget", map.GridCoords.Offset(new Vector2(5, 0)));
+            var granted = actions.AddAction(actor, EntityAction)!.Value;
+            var definition = new CEGOAPUseAction
+            {
+                ActionPrototype = EntityAction,
+                Selector = new CEGOAPSelectorNearestEntity { Range = 10, Whitelist = new EntityWhitelist { Tags = new() { "CECheckedTarget" } } },
+            };
+
+            actions.SetEnabled(granted, false);
+            var unavailable = new CEGOAPActionUpdateEvent<CEGOAPUseAction>(definition, 0.1f);
+            SEntMan.EventBus.RaiseLocalEvent(actor, ref unavailable);
+            Assert.That(unavailable.Status, Is.EqualTo(CEGOAPActionStatus.Failed));
+            Assert.That(backoff.IsRejected(actor, target), Is.False);
+
+            actions.SetEnabled(granted, true);
+            var badTarget = new CEGOAPActionUpdateEvent<CEGOAPUseAction>(definition, 0.1f);
+            SEntMan.EventBus.RaiseLocalEvent(actor, ref badTarget);
+            Assert.That(badTarget.Status, Is.EqualTo(CEGOAPActionStatus.Failed));
+            Assert.That(backoff.IsRejected(actor, target), Is.True);
+            Assert.That(SComp<CECheckedActionProbeComponent>(actor).Calls, Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task SynchronousCallerCannotSkipDoAfterAndUnhandledEventIsNotSuccess()
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid actor = default;
+        await Server.WaitAssertion(() =>
+        {
+            var actions = Server.System<SharedActionsSystem>();
+            actor = SEntMan.SpawnEntity("CECheckedActor", map.GridCoords);
+            var target = SEntMan.SpawnEntity("CECheckedTarget", map.GridCoords.Offset(new Vector2(0.5f, 0)));
+            var immediate = actions.AddAction(actor, EntityAction)!.Value;
+            var probe = SComp<CECheckedActionProbeComponent>(actor);
+            var request = new RequestPerformActionEvent(SEntMan.GetNetEntity(immediate), SEntMan.GetNetEntity(target));
+            Assert.That(actions.TryPerformActionChecked(request, actor), Is.EqualTo(CEActionExecutionResult.Performed));
+            probe.Accept = false;
+            Assert.That(actions.TryPerformActionChecked(request, actor), Is.EqualTo(CEActionExecutionResult.Unhandled));
+            Assert.That(probe.Calls, Is.EqualTo(1));
+            probe.Accept = true;
+
+            var delayed = actions.AddAction(actor, DelayedAction)!.Value;
+            var delayedRequest = new RequestPerformActionEvent(SEntMan.GetNetEntity(delayed), SEntMan.GetNetEntity(target));
+            Assert.That(actions.TryPerformActionChecked(delayedRequest, actor, allowDoAfter: false), Is.EqualTo(CEActionExecutionResult.Unavailable));
+            Assert.That(probe.Calls, Is.EqualTo(1));
+            Assert.That(actions.TryPerformActionChecked(delayedRequest, actor), Is.EqualTo(CEActionExecutionResult.Started));
+            Assert.That(probe.Calls, Is.EqualTo(1));
+            var pending = SComp<DoAfterComponent>(actor).DoAfters.Values.Single();
+            var pendingEvent = (ActionDoAfterEvent) pending.Args.Event;
+            Assert.That(pendingEvent.Predicted, Is.True);
+            Assert.That(pendingEvent.ShowPopups, Is.True);
+        });
+        await Server.WaitRunTicks(30);
+        await Server.WaitAssertion(() => Assert.That(SComp<CECheckedActionProbeComponent>(actor).Calls, Is.EqualTo(2)));
+    }
+
+    [Test]
+    public async Task RepeatingDoAfterSurvivesUnhandledEventsAndRetainsRequestOptions()
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid actor = default;
+        EntityUid action = default;
+        Content.Shared.DoAfter.DoAfter pending = default!;
+        await Server.WaitAssertion(() =>
+        {
+            var actions = Server.System<SharedActionsSystem>();
+            actor = SEntMan.SpawnEntity("CECheckedActor", map.GridCoords);
+            var target = SEntMan.SpawnEntity("CECheckedTarget", map.GridCoords.Offset(new Vector2(0.5f, 0)));
+            action = actions.AddAction(actor, RepeatingAction)!.Value;
+            SComp<CECheckedActionProbeComponent>(actor).Accept = false;
+            var request = new RequestPerformActionEvent(SEntMan.GetNetEntity(action), SEntMan.GetNetEntity(target));
+
+            Assert.That(actions.TryPerformActionChecked(request, actor, predicted: false, showPopups: false),
+                Is.EqualTo(CEActionExecutionResult.Started));
+            pending = SComp<DoAfterComponent>(actor).DoAfters.Values.Single();
+            var pendingEvent = (ActionDoAfterEvent) pending.Args.Event;
+            Assert.That(pendingEvent.Predicted, Is.False);
+            Assert.That(pendingEvent.ShowPopups, Is.False);
+        });
+
+        await Server.WaitRunTicks(30);
+        await Server.WaitAssertion(() =>
+        {
+            var probe = SComp<CECheckedActionProbeComponent>(actor);
+            // Completion re-enters the legacy bool wrapper. Unhandled must still accept the repeat.
+            Assert.That(probe.Dispatches, Is.GreaterThanOrEqualTo(2));
+            Assert.That(probe.Calls, Is.Zero);
+            Assert.That(pending.Cancelled, Is.False);
+            Assert.That(pending.Completed, Is.False);
+            Assert.That(SComp<DoAfterComponent>(actor).DoAfters.Values.Single(), Is.SameAs(pending));
+            var pendingEvent = (ActionDoAfterEvent) pending.Args.Event;
+            Assert.That(pendingEvent.Predicted, Is.False);
+            Assert.That(pendingEvent.ShowPopups, Is.False);
+            probe.Accept = true;
+        });
+
+        await Server.WaitRunTicks(15);
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(SComp<CECheckedActionProbeComponent>(actor).Calls, Is.GreaterThan(0));
+            Server.System<SharedActionsSystem>().SetEnabled(action, false);
+        });
+        await Server.WaitRunTicks(15);
+        await Server.WaitAssertion(() => Assert.That(pending.Cancelled, Is.True));
+    }
+}
+
+[RegisterComponent]
+public sealed partial class CECheckedActionProbeComponent : Component
+{
+    public int Calls;
+    public int Dispatches;
+    public EntityUid? LastTarget;
+    public bool Accept = true;
+}
+
+public sealed partial class CECheckedEntityEvent : EntityTargetActionEvent;
+public sealed partial class CECheckedWorldEvent : WorldTargetActionEvent;
+
+public sealed partial class CECheckedActionProbeSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<CECheckedEntityEvent>(OnEntity);
+        SubscribeLocalEvent<CECheckedWorldEvent>(OnWorld);
+    }
+
+    private void OnEntity(CECheckedEntityEvent args)
+    {
+        if (!TryComp<CECheckedActionProbeComponent>(args.Performer, out var probe))
+            return;
+        probe.Dispatches++;
+        if (!probe.Accept)
+            return;
+        probe.Calls++;
+        probe.LastTarget = args.Target;
+        args.Handled = true;
+    }
+
+    private void OnWorld(CECheckedWorldEvent args)
+    {
+        if (!TryComp<CECheckedActionProbeComponent>(args.Performer, out var probe) || !probe.Accept)
+            return;
+        probe.Calls++;
+        args.Handled = true;
+    }
+}

--- a/Content.Server/_CE/Actions/CEGrantedActionResolverSystem.cs
+++ b/Content.Server/_CE/Actions/CEGrantedActionResolverSystem.cs
@@ -1,0 +1,39 @@
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._CE.Actions;
+
+/// <summary>
+/// Resolves one uniquely granted action by prototype without taking ownership of action granting.
+/// </summary>
+public sealed partial class CEGrantedActionResolverSystem : EntitySystem
+{
+    [Dependency] private SharedActionsSystem _actions = default!;
+
+    public bool TryResolveUnique(
+        EntityUid holder,
+        EntProtoId prototype,
+        out Entity<ActionComponent> resolved)
+    {
+        resolved = default;
+        var found = false;
+
+        foreach (var action in _actions.GetActions(holder))
+        {
+            if (MetaData(action).EntityPrototype?.ID != (string) prototype)
+                continue;
+
+            if (found)
+            {
+                resolved = default;
+                return false;
+            }
+
+            resolved = action;
+            found = true;
+        }
+
+        return found;
+    }
+}

--- a/Content.Server/_CE/GOAP/Actions/CEGOAPMoveToTargetActionSystem.cs
+++ b/Content.Server/_CE/GOAP/Actions/CEGOAPMoveToTargetActionSystem.cs
@@ -31,6 +31,12 @@ public sealed partial class CEGOAPMoveToTargetAction : CEGOAPActionBase<CEGOAPMo
     public float ReregisterThreshold = 1f;
 }
 
+[RegisterComponent]
+public sealed partial class CEGOAPMoveToTargetComponent : Component
+{
+    public EntityUid? Target;
+}
+
 public sealed partial class CEGOAPMoveToTargetActionSystem : CEGOAPActionSystem<CEGOAPMoveToTargetAction>
 {
     [Dependency] private NPCSteeringSystem _steering = default!;
@@ -59,6 +65,7 @@ public sealed partial class CEGOAPMoveToTargetActionSystem : CEGOAPActionSystem<
         Entity<CEGOAPComponent> ent,
         ref CEGOAPActionStartupEvent<CEGOAPMoveToTargetAction> args)
     {
+        _steering.Unregister(ent);
         RegisterSteering(ent, args.Action);
     }
 
@@ -66,8 +73,11 @@ public sealed partial class CEGOAPMoveToTargetActionSystem : CEGOAPActionSystem<
         Entity<CEGOAPComponent> ent,
         ref CEGOAPActionUpdateEvent<CEGOAPMoveToTargetAction> args)
     {
-        if (!TryResolveCoords(ent, args.Action.Selector, out var coords))
+        if (!TryResolveCoords(ent, args.Action.Selector, out var coords, out args.Target))
+        {
+            args.Status = CEGOAPActionStatus.Failed;
             return;
+        }
 
 
         if (!_xformQuery.TryGetComponent(ent, out var npcXform))
@@ -79,15 +89,21 @@ public sealed partial class CEGOAPMoveToTargetActionSystem : CEGOAPActionSystem<
         // If on different maps, we are doing cross-Z navigation — never report Finished directly.
         var sameMaps = npcXform.MapUid == _transform.GetMap(coords);
 
+        var state = EnsureComp<CEGOAPMoveToTargetComponent>(ent);
+        var retargeted = state.Target != args.Target;
+
         // Re-register steering if target has moved significantly
         if (_steeringQuery.TryComp(ent, out var steering))
         {
             // Re-register if target moved significantly (only for same-map direct nav)
-            if (sameMaps && steering.Coordinates.TryDistance(EntityManager, coords, out var delta)
-                         && delta > args.Action.ReregisterThreshold)
+            if (retargeted || sameMaps &&
+                steering.Coordinates.TryDistance(EntityManager, coords, out var delta) &&
+                delta > args.Action.ReregisterThreshold)
             {
-                var comp = _steering.Register(ent, coords);
-                comp.Range = args.Action.Range;
+                // A new target needs a new request, not the previous target's terminal status.
+                _steering.Unregister(ent);
+                RegisterSteering(ent, args.Action);
+                return;
             }
 
             switch (steering.Status)
@@ -134,7 +150,9 @@ public sealed partial class CEGOAPMoveToTargetActionSystem : CEGOAPActionSystem<
             }
         }
 
-        args.Status = CEGOAPActionStatus.Running;
+        args.Status = _steeringQuery.HasComp(ent)
+            ? CEGOAPActionStatus.Running
+            : CEGOAPActionStatus.Failed;
     }
 
     protected override void OnActionShutdown(
@@ -144,12 +162,15 @@ public sealed partial class CEGOAPMoveToTargetActionSystem : CEGOAPActionSystem<
         _pendingAscent.Remove(ent.Owner);
         _pendingDescent.Remove(ent.Owner);
         _steering.Unregister(ent);
+        RemComp<CEGOAPMoveToTargetComponent>(ent);
     }
 
     private void RegisterSteering(Entity<CEGOAPComponent> ent, CEGOAPMoveToTargetAction action)
     {
-        if (!TryResolveCoords(ent, action.Selector, out var coords))
+        if (!TryResolveCoords(ent, action.Selector, out var coords, out var target))
             return;
+
+        EnsureComp<CEGOAPMoveToTargetComponent>(ent).Target = target;
 
         if (!_xformQuery.TryGetComponent(ent, out var npcXform))
             return;

--- a/Content.Server/_CE/GOAP/Actions/CEGOAPUseActionSystem.cs
+++ b/Content.Server/_CE/GOAP/Actions/CEGOAPUseActionSystem.cs
@@ -1,16 +1,20 @@
 using Content.Shared._CE.GOAP;
 using Content.Shared._CE.GOAP.Components;
+using Content.Shared._CE.GOAP.Selectors;
+using Content.Shared._CE.Actions;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Actions.Events;
+using Content.Shared.DoAfter;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Server._CE.GOAP.Actions;
 
 /// <summary>
-/// Triggers action (Instant, EntityTarget, or WorldTarget).
-/// The action type is auto-detected from the components on the action entity.
+/// Triggers a synchronous action (Instant, EntityTarget, or WorldTarget).
+/// The action type is auto-detected from the components on the action entity;
+/// DoAfter-backed actions are rejected because their execution is not synchronous.
 /// </summary>
 public sealed partial class CEGOAPUseAction : CEGOAPActionBase<CEGOAPUseAction>
 {
@@ -20,6 +24,17 @@ public sealed partial class CEGOAPUseAction : CEGOAPActionBase<CEGOAPUseAction>
     [DataField(required: true)]
     public EntProtoId ActionPrototype;
 }
+
+/// <summary>
+/// Raised when a target fails validation or its synchronous action event is not handled.
+/// Actor-level readiness failures do not reject an otherwise usable target.
+/// Carries the target resolved for that exact attempt so optional policies do not have to
+/// resolve either the selector or granted action again.
+/// </summary>
+[ByRefEvent]
+public readonly record struct CEGOAPUseActionTargetFailedEvent(
+    CEGOAPTargetSelector Selector,
+    EntityUid Target);
 
 public sealed partial class CEGOAPUseActionSystem : CEGOAPActionSystem<CEGOAPUseAction>
 {
@@ -45,19 +60,10 @@ public sealed partial class CEGOAPUseActionSystem : CEGOAPActionSystem<CEGOAPUse
     {
         var actionEntity = FindActionEntity(ent, args.Action.ActionPrototype);
 
-        if (actionEntity == null)
-            return;
-
-        if (!TryComp<ActionComponent>(actionEntity.Value, out var actionComp))
-        {
-            args.CanExecute = false;
-            return;
-        }
-
-        //TODO: this should be really inside vanilla Action system, something like CanPerform method
-        var attemptEv = new ActionAttemptEvent(ent);
-        RaiseLocalEvent(actionEntity.Value, ref attemptEv);
-        if (attemptEv.Cancelled)
+        if (actionEntity == null ||
+            !TryComp<ActionComponent>(actionEntity.Value, out var actionComp) ||
+            !actionComp.Enabled ||
+            HasComp<DoAfterArgsComponent>(actionEntity.Value))
         {
             args.CanExecute = false;
             return;
@@ -82,47 +88,80 @@ public sealed partial class CEGOAPUseActionSystem : CEGOAPActionSystem<CEGOAPUse
             return;
         }
 
-        if (!TryComp<ActionComponent>(actionEntity.Value, out var actionComp))
-        {
-            args.Status = CEGOAPActionStatus.Failed;
-            return;
-        }
-
-        // Still on cooldown — fail immediately so the planner can pick alternatives
-        if (_actions.IsCooldownActive(actionComp))
-        {
-            args.Status = CEGOAPActionStatus.Failed;
-            return;
-        }
-
-        // Determine the target entity for EntityTarget / WorldTarget actions
-        EntityUid? target = null;
+        CEGOAPSelectorResult target = default;
         if (args.Action.Selector != null)
+            target = args.Action.Selector.Resolve(ent, EntityManager);
+
+        args.Target = target.Entity;
+        if (!TryCreateRequest(actionEntity.Value, target, out var request))
         {
-            var result = args.Action.Selector.Resolve(ent, EntityManager);
-            target = result.Entity;
+            args.Status = CEGOAPActionStatus.Failed;
+            return;
         }
 
-        // Set target on the action event based on auto-detected type
-        if (_entityTargetQuery.HasComponent(actionEntity.Value) ||
-            _worldTargetQuery.HasComponent(actionEntity.Value))
-        {
-            if (target == null)
-            {
-                args.Status = CEGOAPActionStatus.Failed;
-                return;
-            }
+        var result = _actions.TryPerformActionChecked(request, ent.Owner, allowDoAfter: false, predicted: false, showPopups: false);
+        args.Status = result == CEActionExecutionResult.Performed ? CEGOAPActionStatus.Finished : CEGOAPActionStatus.Failed;
+        // A cooldown, action blocker or exhausted charge must not blacklist a usable destination.
+        if (result is CEActionExecutionResult.InvalidTarget or CEActionExecutionResult.Unhandled)
+            RaiseTargetFailed(ent.Owner, args.Action.Selector, target.Entity);
+    }
 
-            _actions.SetEventTarget(actionEntity.Value, target.Value);
+    private void RaiseTargetFailed(EntityUid user, CEGOAPTargetSelector? selector, EntityUid? target)
+    {
+        if (selector != null && target is { } failedTarget)
+        {
+            var failed = new CEGOAPUseActionTargetFailedEvent(selector, failedTarget);
+            RaiseLocalEvent(user, ref failed);
+        }
+    }
+
+    private bool TryCreateRequest(
+        EntityUid action,
+        CEGOAPSelectorResult target,
+        out RequestPerformActionEvent request)
+    {
+        request = default!;
+        var hasEntityTarget = _entityTargetQuery.HasComp(action);
+        var hasWorldTarget = _worldTargetQuery.HasComp(action);
+        var targetEntity = target.Entity;
+        var targetPosition = target.Position;
+
+        if (hasWorldTarget && targetPosition == null && targetEntity is { } positioned &&
+            TryComp(positioned, out TransformComponent? transform))
+        {
+            targetPosition = transform.Coordinates;
         }
 
-        _actions.PerformAction(ent.Owner, (actionEntity.Value, actionComp), predicted: false);
-        args.Status = CEGOAPActionStatus.Finished;
+        if ((hasEntityTarget && !hasWorldTarget && targetEntity == null) ||
+            (hasWorldTarget && targetPosition == null))
+            return false;
+
+        var netAction = GetNetEntity(action);
+        if (hasWorldTarget)
+        {
+            var netCoordinates = GetNetCoordinates(targetPosition!.Value);
+            request = hasEntityTarget
+                ? new RequestPerformActionEvent(
+                    netAction,
+                    targetEntity is { } entity ? GetNetEntity(entity) : null,
+                    netCoordinates)
+                : new RequestPerformActionEvent(netAction, netCoordinates);
+        }
+        else if (hasEntityTarget)
+        {
+            request = new RequestPerformActionEvent(netAction, GetNetEntity(targetEntity!.Value));
+        }
+        else
+        {
+            request = new RequestPerformActionEvent(netAction);
+        }
+
+        return true;
     }
 
     /// <summary>
     /// Finds an already-granted action entity matching the prototype ID.
-    /// Does NOT grant a new action — used during planning feasibility checks.
+    /// Does NOT grant a new action; used during planning feasibility checks.
     /// </summary>
     private EntityUid? FindActionEntity(Entity<CEGOAPComponent> ent, EntProtoId actionProto)
     {

--- a/Content.Server/_CE/GOAP/CEGOAPActionSystem.cs
+++ b/Content.Server/_CE/GOAP/CEGOAPActionSystem.cs
@@ -66,13 +66,19 @@ public abstract partial class CEGOAPActionSystem<T> : EntitySystem where T : CEG
     /// Resolves a <see cref="CEGOAPTargetSelector"/> to world coordinates.
     /// Prefers the resolved entity's transform, falling back to a raw position.
     /// </summary>
-    protected bool TryResolveCoords(EntityUid agent, CEGOAPTargetSelector? selector, out EntityCoordinates coords)
+    protected bool TryResolveCoords(
+        EntityUid agent,
+        CEGOAPTargetSelector? selector,
+        out EntityCoordinates coords,
+        out EntityUid? target)
     {
         coords = default;
+        target = null;
         if (selector == null)
             return false;
 
         var result = selector.Resolve(agent, EntityManager);
+        target = result.Entity;
         if (result.Entity is { } e && _coordsXformQuery.TryGetComponent(e, out var xform))
         {
             coords = xform.Coordinates;

--- a/Content.Server/_CE/GOAP/Navigation/CEGOAPTargetBackoffSystem.cs
+++ b/Content.Server/_CE/GOAP/Navigation/CEGOAPTargetBackoffSystem.cs
@@ -1,0 +1,152 @@
+using Content.Server._CE.GOAP.Actions;
+using Content.Shared._CE.GOAP;
+using Content.Shared.Interaction;
+using Robust.Shared.Timing;
+
+namespace Content.Server._CE.GOAP.Navigation;
+
+/// <summary>Selectors whose resolved targets can be excluded after a failed attempt.</summary>
+public interface ICEGOAPTargetBackoffSelector
+{
+}
+
+/// <summary>
+/// Opt-in policy and runtime state for temporarily excluding failed GOAP targets.
+/// Selection and movement systems remain responsible for their own domain behavior.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CEGOAPTargetBackoffComponent : Component
+{
+    [DataField(required: true)]
+    public TimeSpan Duration;
+
+    /// <summary>
+    /// Hard bound for per-agent target history. Oldest deadlines are evicted first.
+    /// </summary>
+    [DataField]
+    public int MaxEntries = 32;
+
+    public readonly Dictionary<EntityUid, TimeSpan> UntilByTarget = new();
+}
+
+/// <summary>
+/// Owns bounded per-agent target exclusions without taking ownership of target
+/// selection, movement, or pathfinding.
+/// </summary>
+public sealed partial class CEGOAPTargetBackoffSystem : EntitySystem
+{
+    [Dependency] private SharedInteractionSystem _interaction = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    [SubscribeLocalEvent]
+    private void OnTargetFailed(
+        Entity<CEGOAPTargetBackoffComponent> ent,
+        ref CEGOAPUseActionTargetFailedEvent args)
+    {
+        if (args.Selector is ICEGOAPTargetBackoffSelector)
+            Reject(ent.Owner, args.Target);
+    }
+
+    [SubscribeLocalEvent(after: [typeof(CEGOAPMoveToTargetActionSystem)])]
+    private void OnMoveUpdate(
+        Entity<CEGOAPTargetBackoffComponent> ent,
+        ref CEGOAPActionUpdateEvent<CEGOAPMoveToTargetAction> args)
+    {
+        if (args.Action.Selector is not ICEGOAPTargetBackoffSelector || args.Target is not { } target)
+            return;
+
+        if (args.Status == CEGOAPActionStatus.Finished && !_interaction.InRangeAndAccessible(ent.Owner, target))
+            args.Status = CEGOAPActionStatus.Failed;
+
+        if (args.Status == CEGOAPActionStatus.Failed)
+            Reject(ent.Owner, target);
+    }
+
+    public void Prune(EntityUid agent)
+    {
+        if (!TryComp<CEGOAPTargetBackoffComponent>(agent, out var backoff))
+            return;
+
+        Prune(backoff);
+    }
+
+    public bool IsRejected(EntityUid agent, EntityUid target)
+    {
+        if (!TryComp<CEGOAPTargetBackoffComponent>(agent, out var backoff) ||
+            !backoff.UntilByTarget.TryGetValue(target, out var until))
+            return false;
+
+        if (Exists(target) && _timing.CurTime < until)
+            return true;
+
+        backoff.UntilByTarget.Remove(target);
+        return false;
+    }
+
+    public bool Reject(EntityUid agent, EntityUid target)
+    {
+        if (!Exists(target) ||
+            !TryComp<CEGOAPTargetBackoffComponent>(agent, out var backoff) ||
+            backoff.Duration <= TimeSpan.Zero ||
+            backoff.MaxEntries <= 0)
+            return false;
+
+        Prune(backoff);
+
+        var until = _timing.CurTime + backoff.Duration;
+        if (backoff.UntilByTarget.TryGetValue(target, out var current))
+        {
+            if (current < until)
+                backoff.UntilByTarget[target] = until;
+
+            return true;
+        }
+
+        while (backoff.UntilByTarget.Count >= backoff.MaxEntries)
+            RemoveEarliest(backoff);
+
+        backoff.UntilByTarget.Add(target, until);
+        return true;
+    }
+
+    private void Prune(CEGOAPTargetBackoffComponent backoff)
+    {
+        while (TryFindStale(backoff, out var stale))
+            backoff.UntilByTarget.Remove(stale);
+    }
+
+    private bool TryFindStale(CEGOAPTargetBackoffComponent backoff, out EntityUid stale)
+    {
+        var now = _timing.CurTime;
+        foreach (var (target, until) in backoff.UntilByTarget)
+        {
+            if (Exists(target) && now < until)
+                continue;
+
+            stale = target;
+            return true;
+        }
+
+        stale = default;
+        return false;
+    }
+
+    private static void RemoveEarliest(CEGOAPTargetBackoffComponent backoff)
+    {
+        EntityUid? earliestTarget = null;
+        TimeSpan? earliestUntil = null;
+        foreach (var (target, until) in backoff.UntilByTarget)
+        {
+            if (earliestUntil is { } currentUntil &&
+                (until > currentUntil ||
+                 until == currentUntil && earliestTarget is { } current && target.Id > current.Id))
+                continue;
+
+            earliestTarget = target;
+            earliestUntil = until;
+        }
+
+        if (earliestTarget is { } earliest)
+            backoff.UntilByTarget.Remove(earliest);
+    }
+}

--- a/Content.Server/_CE/GOAP/Selectors/CEGOAPSelectorNearestEntity.cs
+++ b/Content.Server/_CE/GOAP/Selectors/CEGOAPSelectorNearestEntity.cs
@@ -1,0 +1,76 @@
+using System.Numerics;
+using Content.Server._CE.GOAP.Navigation;
+using Content.Shared._CE.GOAP.Selectors;
+using Content.Shared.Whitelist;
+
+namespace Content.Server._CE.GOAP.Selectors;
+
+/// <summary>
+/// Selects the nearest in-range entity matching prototype-authored whitelist rules.
+/// </summary>
+[DataDefinition]
+public sealed partial class CEGOAPSelectorNearestEntity
+    : CEGOAPTargetSelectorBase<CEGOAPSelectorNearestEntity>, ICEGOAPTargetBackoffSelector
+{
+    [DataField(required: true)]
+    public float Range;
+
+    [DataField(required: true)]
+    public EntityWhitelist Whitelist = default!;
+
+    [DataField]
+    public EntityWhitelist? Blacklist;
+
+    [DataField]
+    public bool IncludeSelf;
+}
+
+public sealed partial class CEGOAPSelectorNearestEntitySystem
+    : CEGOAPTargetSelectorSystem<CEGOAPSelectorNearestEntity>
+{
+    [Dependency] private CEGOAPTargetBackoffSystem _backoff = default!;
+    [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
+
+    protected override void Resolve(ref CEGOAPSelectorResolveEvent<CEGOAPSelectorNearestEntity> ev)
+    {
+        if (!float.IsFinite(ev.Selector.Range) || ev.Selector.Range < 0f ||
+            !TryComp(ev.Agent, out TransformComponent? origin))
+            return;
+
+        var originPosition = _transform.GetWorldPosition(origin);
+        var bestDistance = float.MaxValue;
+        EntityUid? best = null;
+        _backoff.Prune(ev.Agent);
+
+        foreach (var candidate in _lookup.GetEntitiesInRange(
+                     origin.Coordinates,
+                     ev.Selector.Range,
+                     LookupFlags.Uncontained))
+        {
+            if (!ev.Selector.IncludeSelf && candidate == ev.Agent ||
+                !_whitelist.CheckBoth(candidate, ev.Selector.Blacklist, ev.Selector.Whitelist) ||
+                _backoff.IsRejected(ev.Agent, candidate) ||
+                !TryComp(candidate, out TransformComponent? candidateTransform) ||
+                candidateTransform.MapID != origin.MapID)
+                continue;
+
+            var distance = Vector2.DistanceSquared(
+                originPosition,
+                _transform.GetWorldPosition(candidateTransform));
+            if (!float.IsFinite(distance) || distance > bestDistance ||
+                distance.Equals(bestDistance) && best is { } current && candidate.Id > current.Id)
+                continue;
+
+            best = candidate;
+            bestDistance = distance;
+        }
+
+        if (best is not { } result || !TryComp(result, out TransformComponent? resultTransform))
+            return;
+
+        ev.Entity = result;
+        ev.Position = resultTransform.Coordinates;
+    }
+}

--- a/Content.Server/_CE/GOAP/Selectors/CEGOAPSelectorProfile.cs
+++ b/Content.Server/_CE/GOAP/Selectors/CEGOAPSelectorProfile.cs
@@ -1,0 +1,57 @@
+using Content.Server._CE.GOAP.Navigation;
+using Content.Shared._CE.GOAP.Selectors;
+
+namespace Content.Server._CE.GOAP.Selectors;
+
+/// <summary>
+/// Named, prototype-authored target policies shared by sensors and actions on
+/// the same agent. Profiles are restricted to backoff-capable entity selectors
+/// so wrapping them cannot change failure semantics.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CEGOAPSelectorProfilesComponent : Component
+{
+    [DataField, AlwaysPushInheritance]
+    public Dictionary<string, CEGOAPTargetSelector> Profiles = new();
+}
+
+/// <summary>
+/// Resolves one concrete selector from <see cref="CEGOAPSelectorProfilesComponent"/>.
+/// </summary>
+[DataDefinition]
+public sealed partial class CEGOAPSelectorProfile
+    : CEGOAPTargetSelectorBase<CEGOAPSelectorProfile>, ICEGOAPTargetBackoffSelector
+{
+    [DataField(required: true)]
+    public string Profile = string.Empty;
+}
+
+public sealed partial class CEGOAPSelectorProfileSystem
+    : CEGOAPTargetSelectorSystem<CEGOAPSelectorProfile>
+{
+    protected override void Resolve(ref CEGOAPSelectorResolveEvent<CEGOAPSelectorProfile> ev)
+    {
+        if (!TryResolveSelector(ev.Agent, ev.Selector, out var selector))
+            return;
+
+        var result = selector.Resolve(ev.Agent, EntityManager);
+        ev.Entity = result.Entity;
+        ev.Position = result.Position;
+    }
+
+    private bool TryResolveSelector(
+        EntityUid agent,
+        CEGOAPSelectorProfile profile,
+        out CEGOAPTargetSelector resolved)
+    {
+        resolved = null!;
+        if (string.IsNullOrWhiteSpace(profile.Profile) ||
+            !TryComp<CEGOAPSelectorProfilesComponent>(agent, out var profiles) ||
+            !profiles.Profiles.TryGetValue(profile.Profile, out var concrete) ||
+            concrete is CEGOAPSelectorProfile or not ICEGOAPTargetBackoffSelector)
+            return false;
+
+        resolved = concrete;
+        return true;
+    }
+}

--- a/Content.Server/_CE/GOAP/Sensors/CEGOAPEntityConditionSensorSystem.cs
+++ b/Content.Server/_CE/GOAP/Sensors/CEGOAPEntityConditionSensorSystem.cs
@@ -1,0 +1,82 @@
+using Content.Shared._CE.GOAP.Components;
+using Content.Shared.EntityConditions;
+using Robust.Shared.Timing;
+
+namespace Content.Server._CE.GOAP.Sensors;
+
+[DataDefinition]
+public sealed partial class CEGOAPEntityConditionSensorEntry
+{
+    [DataField(required: true)]
+    public string ConditionKey = string.Empty;
+
+    [DataField(required: true)]
+    public EntityCondition Condition = default!;
+}
+
+/// <summary>
+/// Publishes standard prototype-authored entity conditions as GOAP facts.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CEGOAPEntityConditionSensorComponent : Component
+{
+    [DataField, AlwaysPushInheritance]
+    public List<CEGOAPEntityConditionSensorEntry> Entries = new();
+
+    [DataField]
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(2);
+
+    [ViewVariables]
+    public TimeSpan NextUpdateTime;
+}
+
+public sealed partial class CEGOAPEntityConditionSensorSystem : EntitySystem
+{
+    [Dependency] private SharedEntityConditionsSystem _conditions = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<
+            CEGOAPEntityConditionSensorComponent,
+            CEGOAPComponent,
+            CEActiveGOAPComponent>();
+
+        while (query.MoveNext(out var uid, out var sensor, out var goap, out _))
+        {
+            // A negative interval opts out of polling while explicit refresh events
+            // remain available to authoritative state owners.
+            if (sensor.UpdateInterval < TimeSpan.Zero || curTime < sensor.NextUpdateTime)
+                continue;
+
+            Evaluate(uid, sensor, goap);
+            sensor.NextUpdateTime = curTime + sensor.UpdateInterval;
+        }
+    }
+
+    [SubscribeLocalEvent]
+    private void OnRefresh(
+        Entity<CEGOAPEntityConditionSensorComponent> ent,
+        ref CEGOAPSensorRefreshEvent args)
+    {
+        if (TryComp<CEGOAPComponent>(ent, out var goap))
+            Evaluate(ent, ent.Comp, goap);
+    }
+
+    private void Evaluate(
+        EntityUid uid,
+        CEGOAPEntityConditionSensorComponent sensor,
+        CEGOAPComponent goap)
+    {
+        foreach (var entry in sensor.Entries)
+        {
+            if (string.IsNullOrWhiteSpace(entry.ConditionKey))
+                continue;
+
+            goap.WorldState[entry.ConditionKey] = _conditions.TryCondition(uid, entry.Condition);
+        }
+    }
+}

--- a/Content.Server/_CE/Production/CEActionChargesCondition.cs
+++ b/Content.Server/_CE/Production/CEActionChargesCondition.cs
@@ -1,0 +1,48 @@
+using Content.Server._CE.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Charges.Components;
+using Content.Shared.Charges.Systems;
+using Content.Shared.EntityConditions;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._CE.Production;
+
+/// <summary>
+/// Checks the standard charges of one uniquely granted action.
+/// </summary>
+public sealed partial class CEActionChargesCondition : EntityConditionBase<CEActionChargesCondition>
+{
+    [DataField(required: true)]
+    public EntProtoId Action;
+
+    [DataField]
+    public int MinimumCharges = 1;
+
+    public override string EntityConditionGuidebookText(IPrototypeManager prototype) => string.Empty;
+}
+
+public sealed partial class CEActionChargesConditionSystem
+    : EntityConditionSystem<ActionsComponent, CEActionChargesCondition>
+{
+    [Dependency] private CEGrantedActionResolverSystem _actionResolver = default!;
+    [Dependency] private SharedChargesSystem _charges = default!;
+
+    [Dependency] private EntityQuery<LimitedChargesComponent> _limitedChargesQuery = default!;
+
+    protected override void Condition(
+        Entity<ActionsComponent> entity,
+        ref EntityConditionEvent<CEActionChargesCondition> args)
+    {
+        if (args.Condition.MinimumCharges < 0 ||
+            !_actionResolver.TryResolveUnique(entity.Owner, args.Condition.Action, out var action) ||
+            !_limitedChargesQuery.TryComp(action, out var limitedCharges))
+        {
+            args.Result = false;
+            return;
+        }
+
+        args.Result = _charges.HasCharges(
+            (action.Owner, limitedCharges),
+            args.Condition.MinimumCharges);
+    }
+}

--- a/Content.Shared/Actions/Events/ActionDoAfterEvent.cs
+++ b/Content.Shared/Actions/Events/ActionDoAfterEvent.cs
@@ -24,12 +24,19 @@ public sealed partial class ActionDoAfterEvent : DoAfterEvent
     /// </summary>
     public readonly RequestPerformActionEvent Input;
 
-    public ActionDoAfterEvent(NetEntity performer, TimeSpan? originalUseDelay, RequestPerformActionEvent input)
+    // CrystallEdge: keep presentation choices with the request during delayed/repeated execution.
+    public readonly bool Predicted;
+    public readonly bool ShowPopups;
+
+    public ActionDoAfterEvent(NetEntity performer, TimeSpan? originalUseDelay, RequestPerformActionEvent input, bool predicted = true, bool showPopups = true)
     {
         Performer = performer;
         OriginalUseDelay = originalUseDelay;
         Input = input;
+        Predicted = predicted;
+        ShowPopups = showPopups;
     }
+    // CrystallEdge end
 
     public override DoAfterEvent Clone() => this;
 }

--- a/Content.Shared/Actions/Events/ActionValidateEvent.cs
+++ b/Content.Shared/Actions/Events/ActionValidateEvent.cs
@@ -29,4 +29,7 @@ public struct ActionValidateEvent
     /// For functioning input that happens to not be allowed this should not be set, for example a range check.
     /// </summary>
     public bool Invalid;
+
+    // CrystallEdge: a valid request may have an unusable target. NPCs must not confuse this with actor readiness.
+    public bool TargetInvalid;
 }

--- a/Content.Shared/Actions/SharedActionsSystem.DoAfter.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.DoAfter.cs
@@ -10,7 +10,9 @@ public abstract partial class SharedActionsSystem
         SubscribeLocalEvent<DoAfterArgsComponent, ActionDoAfterEvent>(OnActionDoAfter);
     }
 
-    private bool TryStartActionDoAfter(Entity<DoAfterArgsComponent> ent, Entity<DoAfterComponent?> performer, TimeSpan? originalUseDelay, RequestPerformActionEvent input)
+    // CrystallEdge: preserve request presentation options through delayed and repeated execution.
+    private bool TryStartActionDoAfter(Entity<DoAfterArgsComponent> ent, Entity<DoAfterComponent?> performer, TimeSpan? originalUseDelay, RequestPerformActionEvent input, bool predicted, bool showPopups)
+    // CrystallEdge end
     {
         // relay to user
         if (!Resolve(performer, ref performer.Comp))
@@ -20,7 +22,7 @@ public abstract partial class SharedActionsSystem
 
         var netEnt = GetNetEntity(performer);
 
-        var actionDoAfterEvent = new ActionDoAfterEvent(netEnt, originalUseDelay, input);
+        var actionDoAfterEvent = new ActionDoAfterEvent(netEnt, originalUseDelay, input, predicted, showPopups); // CrystallEdge: carry options in serialized event state.
 
         var doAfterArgs = new DoAfterArgs(EntityManager, performer, delay, actionDoAfterEvent, ent.Owner, performer)
         {
@@ -76,7 +78,7 @@ public abstract partial class SharedActionsSystem
             args.Args.Delay = ent.Comp.DelayReduction.Value;
 
         // Validate again for charges, blockers, etc
-        if (TryPerformAction(args.Input, performer, skipDoActionRequest: true))
+        if (TryPerformAction(args.Input, performer, skipDoActionRequest: true, showPopups: args.ShowPopups, predicted: args.Predicted)) // CrystallEdge: retain original request options.
             return;
 
         // Cancel this doafter if we can't validate the action

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Shared._CE.Actions;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions.Components;
 using Content.Shared.Actions.Events;
@@ -274,15 +275,41 @@ public abstract partial class SharedActionsSystem : EntitySystem
     /// <param name="ev">The Request Perform Action Event</param>
     /// <param name="user">The user/performer of the action</param>
     /// <param name="skipDoActionRequest">Should this skip the initial doaction request?</param>
-    private bool TryPerformAction(RequestPerformActionEvent ev, EntityUid user, bool skipDoActionRequest = false, bool showPopups = true)
+    // CrystallEdge: only the internal DoAfter callback may bypass starting another delay.
+    private bool TryPerformAction(RequestPerformActionEvent ev, EntityUid user, bool skipDoActionRequest = false, bool showPopups = true, bool predicted = true)
+    {
+        var result = TryPerformActionCore(ev, user, true, predicted, skipDoActionRequest, showPopups);
+        return result is CEActionExecutionResult.Started or CEActionExecutionResult.Performed or CEActionExecutionResult.Unhandled;
+    }
+
+    /// <summary>
+    /// Validates ownership, readiness and the requested target before dispatching the action.
+    /// Synchronous callers can reject DoAfter actions instead of treating a started timer as completion.
+    /// </summary>
+    public CEActionExecutionResult TryPerformActionChecked(
+        RequestPerformActionEvent ev,
+        EntityUid user,
+        bool allowDoAfter = true,
+        bool predicted = true,
+        bool showPopups = true)
+    {
+        return TryPerformActionCore(ev, user, allowDoAfter, predicted, false, showPopups);
+    }
+
+    private CEActionExecutionResult TryPerformActionCore(
+        RequestPerformActionEvent ev,
+        EntityUid user,
+        bool allowDoAfter,
+        bool predicted,
+        bool skipDoActionRequest,
+        bool showPopups)
     {
         if (!_actionsQuery.TryComp(user, out var component))
-            return false;
+            return CEActionExecutionResult.Unavailable;
 
-        var actionEnt = GetEntity(ev.Action);
-
-        if (!TryComp(actionEnt, out MetaDataComponent? metaData))
-            return false;
+        if (!TryGetEntity(ev.Action, out var resolvedAction) || resolvedAction is not { } actionEnt ||
+            !TryComp(actionEnt, out MetaDataComponent? metaData))
+            return CEActionExecutionResult.Unavailable;
 
         var name = Name(actionEnt, metaData);
 
@@ -291,19 +318,19 @@ public abstract partial class SharedActionsSystem : EntitySystem
         {
             _adminLogger.Add(LogType.Action,
                 $"{ToPrettyString(user):user} attempted to perform an action that they do not have: {name}.");
-            return false;
+            return CEActionExecutionResult.Unavailable;
         }
 
         if (GetAction(actionEnt) is not {} action)
-            return false;
+            return CEActionExecutionResult.Unavailable;
 
-        DebugTools.Assert(action.Comp.AttachedEntity == user);
-        if (!action.Comp.Enabled)
-            return false;
+        if (action.Comp.AttachedEntity != user || !action.Comp.Enabled ||
+            !allowDoAfter && HasComp<DoAfterArgsComponent>(action))
+            return CEActionExecutionResult.Unavailable;
 
         var curTime = GameTiming.CurTime;
         if (IsCooldownActive(action, curTime))
-            return false;
+            return CEActionExecutionResult.Unavailable;
 
         // check for action use prevention
         var attemptEv = new ActionAttemptEvent(user);
@@ -313,8 +340,11 @@ public abstract partial class SharedActionsSystem : EntitySystem
             if (attemptEv.Reason != null && showPopups)
                 _popup.PopupEntity(attemptEv.Reason, user, user, attemptEv.Type);
 
-            return false;
+            return CEActionExecutionResult.Unavailable;
         }
+
+        if (TerminatingOrDeleted(action) || !action.Comp.Running)
+            return CEActionExecutionResult.Unavailable;
 
         // Validate request by checking action blockers and the like
         var provider = action.Comp.Container ?? user;
@@ -325,17 +355,28 @@ public abstract partial class SharedActionsSystem : EntitySystem
             Provider = provider
         };
         RaiseLocalEvent(action, ref validateEv);
-        if (validateEv.Invalid)
-            return false;
+        // Actor-level rejection takes precedence even if another handler also rejected the target.
+        if (validateEv.Invalid || TerminatingOrDeleted(action) || !action.Comp.Running)
+            return CEActionExecutionResult.Unavailable;
+        if (validateEv.TargetInvalid)
+            return CEActionExecutionResult.InvalidTarget;
 
         if (TryComp<DoAfterArgsComponent>(action, out var actionDoAfterComp) && TryComp<DoAfterComponent>(user, out var performerDoAfterComp) && !skipDoActionRequest)
         {
-            return TryStartActionDoAfter((action, actionDoAfterComp), (user, performerDoAfterComp), action.Comp.UseDelay, ev);
+            return TryStartActionDoAfter((action, actionDoAfterComp), (user, performerDoAfterComp), action.Comp.UseDelay, ev, predicted, showPopups)
+                ? CEActionExecutionResult.Started
+                : CEActionExecutionResult.Unavailable;
         }
 
         // All checks passed. Perform the action!
-        PerformAction((user, component), action);
-        return true;
+        if (GetEvent(action) is not { } actionEvent)
+            return CEActionExecutionResult.Unavailable;
+
+        // Event instances are reused. An early return in PerformAction must not retain the previous success.
+        actionEvent.Handled = false;
+        PerformAction((user, component), action, actionEvent, predicted);
+        return actionEvent.Handled ? CEActionExecutionResult.Performed : CEActionExecutionResult.Unhandled;
+        // CrystallEdge end
     }
 
     private void OnValidate(Entity<ActionComponent> ent, ref ActionValidateEvent args)
@@ -368,15 +409,24 @@ public abstract partial class SharedActionsSystem : EntitySystem
 
         var user = args.User;
 
-        var target = GetEntity(netTarget);
-
-        var targetWorldPos = _transform.GetWorldPosition(target);
+        // CrystallEdge: reject stale targets before reading their transform or reusing the previous event target.
+        if (!TryGetEntity(netTarget, out var resolvedTarget) ||
+            resolvedTarget is not { } target || !TryComp(target, out TransformComponent? targetTransform))
+        {
+            args.TargetInvalid = true;
+            return;
+        }
+        var targetWorldPos = _transform.GetWorldPosition(targetTransform);
+        // CrystallEdge end
 
         if (ent.Comp.RotateOnUse)
             _rotateToFace.TryFaceCoordinates(user, targetWorldPos);
 
         if (!ValidateEntityTarget(user, target, ent))
+        {
+            args.TargetInvalid = true; // CrystallEdge: a failed target must prevent dispatch.
             return;
+        }
 
         _adminLogger.Add(LogType.Action,
             $"{ToPrettyString(user):user} is performing the {Name(ent):action} action (provided by {ToPrettyString(args.Provider):provider}) targeted at {ToPrettyString(target):target}.");
@@ -392,22 +442,49 @@ public abstract partial class SharedActionsSystem : EntitySystem
             return;
         }
 
+        // CrystallEdge: reject stale coordinate parents before rotating or transforming the target.
+        if (!float.IsFinite(netTarget.X) || !float.IsFinite(netTarget.Y) ||
+            !TryGetEntity(netTarget.NetEntity, out var resolvedParent) ||
+            resolvedParent is not { } parent || TerminatingOrDeleted(parent) ||
+            !HasComp<TransformComponent>(parent))
+        {
+            args.TargetInvalid = true;
+            return;
+        }
+
+        EntityUid? targetEntity = null;
+        if (args.Input.EntityTarget is { } netEntityTarget)
+        {
+            if (!TryGetEntity(netEntityTarget, out var resolvedEntity) ||
+                resolvedEntity is not { } entity || TerminatingOrDeleted(entity) ||
+                !HasComp<TransformComponent>(entity))
+            {
+                args.TargetInvalid = true;
+                return;
+            }
+
+            targetEntity = entity;
+        }
+
         var user = args.User;
-        var target = GetCoordinates(netTarget);
+        var target = new EntityCoordinates(parent, netTarget.Position);
+        // CrystallEdge end
 
         if (ent.Comp.RotateOnUse)
             _rotateToFace.TryFaceCoordinates(user, _transform.ToMapCoordinates(target).Position);
 
         if (!ValidateWorldTarget(user, target, ent))
+        {
+            args.TargetInvalid = true; // CrystallEdge: a failed target must prevent dispatch.
             return;
+        }
 
         // if the client specified an entity it needs to be valid
-        var targetEntity = GetEntity(args.Input.EntityTarget);
         if (targetEntity != null && (
             !TryComp<EntityTargetActionComponent>(ent, out var entTarget) ||
             !ValidateEntityTarget(user, targetEntity.Value, (ent, entTarget))))
         {
-            args.Invalid = true;
+            args.TargetInvalid = true; // CrystallEdge: valid request, rejected optional entity target.
             return;
         }
 

--- a/Content.Shared/_CE/Actions/CEActionExecutionResult.cs
+++ b/Content.Shared/_CE/Actions/CEActionExecutionResult.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._CE.Actions;
+
+/// <summary>The outcome of the normal action request pipeline, including asynchronous acceptance.</summary>
+public enum CEActionExecutionResult : byte
+{
+    Unavailable,
+    InvalidTarget,
+    Started,
+    Performed,
+    Unhandled,
+}

--- a/Content.Shared/_CE/Actions/CESharedActionSystem.Attempt.cs
+++ b/Content.Shared/_CE/Actions/CESharedActionSystem.Attempt.cs
@@ -87,30 +87,58 @@ public abstract partial class CESharedActionSystem
     [SubscribeLocalEvent]
     private void OnActionSSDAttempt(Entity<CEActionSSDBlockComponent> ent, ref ActionValidateEvent args)
     {
-        if (args.Invalid)
+        if (args.Invalid || args.TargetInvalid || args.Input.EntityTarget is not { } netTarget)
             return;
 
-        if (!TryComp<SSDIndicatorComponent>(GetEntity(args.Input.EntityTarget), out var ssdIndication))
+        if (!TryGetEntity(netTarget, out var resolvedTarget) ||
+            resolvedTarget is not { } target || TerminatingOrDeleted(target))
+        {
+            args.TargetInvalid = true;
+            return;
+        }
+
+        if (!TryComp<SSDIndicatorComponent>(target, out var ssdIndication))
             return;
 
         if (ssdIndication.IsSSD)
         {
             Popup.PopupClient(Loc.GetString("ce-magic-spell-ssd"), args.User, args.User);
-            args.Invalid = true;
+            args.TargetInvalid = true;
         }
     }
 
     [SubscribeLocalEvent]
     private void OnLineOfSightValidate(Entity<CEActionRequireLineOfSightComponent> ent, ref ActionValidateEvent args)
     {
-        if (args.Invalid)
+        if (args.Invalid || args.TargetInvalid)
             return;
 
         EntityCoordinates? target = null;
         if (args.Input.EntityCoordinatesTarget is { } netCoords)
-            target = GetCoordinates(netCoords);
-        else if (GetEntity(args.Input.EntityTarget) is { Valid: true } targetEntity)
-            target = Transform(targetEntity).Coordinates;
+        {
+            if (!float.IsFinite(netCoords.X) || !float.IsFinite(netCoords.Y) ||
+                !TryGetEntity(netCoords.NetEntity, out var resolvedParent) ||
+                resolvedParent is not { } parent || TerminatingOrDeleted(parent) ||
+                !HasComp<TransformComponent>(parent))
+            {
+                args.TargetInvalid = true;
+                return;
+            }
+
+            target = new EntityCoordinates(parent, netCoords.Position);
+        }
+        else if (args.Input.EntityTarget is { } netEntity)
+        {
+            if (!TryGetEntity(netEntity, out var resolvedTarget) ||
+                resolvedTarget is not { } entity || TerminatingOrDeleted(entity) ||
+                !TryComp(entity, out TransformComponent? transform))
+            {
+                args.TargetInvalid = true;
+                return;
+            }
+
+            target = transform.Coordinates;
+        }
 
         if (target is not { } coords)
             return;
@@ -123,7 +151,7 @@ public abstract partial class CESharedActionSystem
             return;
 
         Popup.PopupClient(Loc.GetString("dash-ability-cant-see"), args.User, args.User);
-        args.Invalid = true;
+        args.TargetInvalid = true;
     }
 
     [SubscribeLocalEvent]

--- a/Content.Shared/_CE/GOAP/Interfaces/CEGOAPAction.cs
+++ b/Content.Shared/_CE/GOAP/Interfaces/CEGOAPAction.cs
@@ -153,6 +153,13 @@ public record struct CEGOAPActionStartupEvent<T>(T Action) where T : CEGOAPActio
 public record struct CEGOAPActionUpdateEvent<T>(T Action, float FrameTime) where T : CEGOAPActionBase<T>
 {
     public CEGOAPActionStatus Status = CEGOAPActionStatus.Running;
+
+    /// <summary>
+    /// Optional target resolved by this action for the current update. Result
+    /// policies can use the exact attempted target without resolving it again.
+    /// Actions without an entity target leave this null.
+    /// </summary>
+    public EntityUid? Target;
 }
 
 /// <summary>


### PR DESCRIPTION
## About the PR

GOAP должен отличать отказ цели, недоступность исполнителя, начало DoAfter и фактическое выполнение. Добавлен проверяемый вызов штатного Action pipeline; неуспешная цель получает backoff, а уже выбранная цель сохраняется до завершения операции.

## Why / Balance

Общая механика вынесена из животноводства для отдельного ревью, согласно [правилам разделения PR](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#content).

Основание: `master`. Это первый общий API в последовательности для #430; последующие изменения и животноводство рассматриваются отдельными PR.

## Technical details

17 файлов, +1019/−82 строки. Штатные Actions сохраняют валидацию, cooldown, DoAfter и расход LimitedCharges. Общие resolver, selector и condition работают по данным; зависимостей от AnimalHusbandry и видовых прототипов нет.

## Test plan

`CECheckedActionsTest`: отказ entity/world target после успешного вызова, необработанное событие, сохранение параметров повторного DoAfter и корректная цель backoff. В итоговом прогоне дополнительно прошли три штатных теста Actions.

Сборка Content.IntegrationTests (DebugOpt, включая Server/Client) этого промежуточного checkout прошла отдельно. Названные тесты запускались в итоговой композиции A–G: 36/36 Passed, без пропусков; это не заявление об отдельном запуске всего набора на каждой промежуточной ветке. Для воспроизведения: собрать Content.IntegrationTests и запустить названную fixture; для итогового игрового сценария нужен контент #430.

## Media

Графические наблюдения относятся к общей проверенной композиции. Новые изображения к этому PR пока не приложены.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have tested this pull request and written instructions on how to test it.
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

Новый CE API результата выполнения и информация о запросе DoAfter. Существующий публичный вызов Actions сохранён; пропустить штатные проверки через новый API нельзя.
