### PR TITLE
Контейнеры: доступ и отображение содержимого штатных ItemSlots

### DIFF
--- a/Content.Client/_CE/Containers/CEContainerSlotVisualStateComponent.cs
+++ b/Content.Client/_CE/Containers/CEContainerSlotVisualStateComponent.cs
@@ -1,0 +1,19 @@
+using System.Numerics;
+using Content.Shared._CE.ZLevels.Core.Components;
+using Robust.Client.GameObjects;
+
+namespace Content.Client._CE.Containers;
+
+/// <summary>
+/// Client-only runtime state for a fixed-slot visual applied to this entity.
+/// </summary>
+[RegisterComponent]
+internal sealed partial class CEContainerSlotVisualStateComponent : Component
+{
+    public bool Pending;
+
+    public SpriteComponent? OriginalSprite;
+    public CEZPhysicsComponent? OriginalZPhysics;
+    public Vector2 CleanOffset;
+    public Angle? OriginalRotation;
+}

--- a/Content.Client/_CE/Containers/CEContainerSlotVisualSystem.cs
+++ b/Content.Client/_CE/Containers/CEContainerSlotVisualSystem.cs
@@ -1,0 +1,190 @@
+using System.Numerics;
+using Content.Client._CE.ZLevels.Core;
+using Content.Shared._CE.Containers;
+using Content.Shared._CE.ZLevels.Core.Components;
+using Content.Shared.Rotation;
+using Robust.Client.GameObjects;
+
+namespace Content.Client._CE.Containers;
+
+/// <summary>
+/// Applies networked fixed-slot presentation without violating container transform invariants.
+/// Entities with <see cref="RotationVisualsComponent"/> retain exclusive ownership of their
+/// whole-sprite rotation; authored slot rotation is ignored for those entities.
+/// </summary>
+public sealed partial class CEContainerSlotVisualSystem : EntitySystem
+{
+    [Dependency] private SharedAppearanceSystem _appearance = default!;
+    [Dependency] private SpriteSystem _sprite = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        UpdatesBefore.Add(typeof(CEClientZLevelsPreAnimSystem));
+    }
+
+    [SubscribeLocalEvent]
+    private void OnAppearanceChange(Entity<AppearanceComponent> ent, ref AppearanceChangeEvent args)
+    {
+        if (TryComp<CEContainerSlotVisualStateComponent>(ent.Owner, out var state) && state.Running)
+        {
+            state.Pending = true;
+            return;
+        }
+
+        if (!TerminatingOrDeleted(ent.Owner) &&
+            _appearance.TryGetData<bool>(ent.Owner, CEContainerSlotVisuals.Active, out var active, ent.Comp) && active)
+            EnsureComp<CEContainerSlotVisualStateComponent>(ent.Owner).Pending = true;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnAppearanceShutdown(Entity<AppearanceComponent> ent, ref ComponentShutdown args)
+    {
+        if (!TryComp<CEContainerSlotVisualStateComponent>(ent.Owner, out var state))
+            return;
+
+        RemCompDeferred(ent.Owner, state);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnStateShutdown(Entity<CEContainerSlotVisualStateComponent> ent, ref ComponentShutdown args)
+    {
+        Restore(ent.Owner, ent.Comp);
+        ent.Comp.Pending = false;
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
+
+        var query = EntityQueryEnumerator<CEContainerSlotVisualStateComponent>();
+        while (query.MoveNext(out var uid, out var state))
+        {
+            if (!state.Running || TerminatingOrDeleted(uid))
+                continue;
+
+            Refresh(uid, state);
+        }
+    }
+
+    /// <summary>
+    /// Appearance initial state can arrive before the sprite initial state on a client.
+    /// Keep the active visual's state until its sprite is ready, without a separate retry queue.
+    /// </summary>
+    private void Refresh(EntityUid uid, CEContainerSlotVisualStateComponent state)
+    {
+        if (!TryComp<AppearanceComponent>(uid, out var appearance) ||
+            !_appearance.TryGetData<bool>(uid, CEContainerSlotVisuals.Active, out var active, appearance) ||
+            !active)
+        {
+            RemCompDeferred(uid, state);
+            return;
+        }
+
+        if (!TryComp<SpriteComponent>(uid, out var sprite) || !sprite.Running)
+        {
+            Restore(uid, state);
+            return;
+        }
+
+        CEZPhysicsComponent? zPhysics = null;
+        if (TryComp<CEZPhysicsComponent>(uid, out var candidateZPhysics) && candidateZPhysics.Running)
+            zPhysics = candidateZPhysics;
+        // Keep slot state local; the existing Z-level renderer owns its baseline.
+        if (!ReferenceEquals(state.OriginalSprite, sprite) ||
+            !ReferenceEquals(state.OriginalZPhysics, zPhysics))
+        {
+            var cleanOffset = ReferenceEquals(state.OriginalSprite, sprite)
+                ? state.CleanOffset
+                : sprite.Offset;
+            Restore(uid, state);
+            state.OriginalSprite = sprite;
+            state.OriginalZPhysics = zPhysics;
+            state.CleanOffset = cleanOffset;
+            state.OriginalRotation = HasComp<RotationVisualsComponent>(uid) ? null : sprite.Rotation;
+            state.Pending = true;
+        }
+
+        // Only rewrite the offset when slot data or its visual owner changes.
+        // Stable visuals must preserve offsets written by the animation player this frame.
+        if (state.Pending)
+        {
+            _appearance.TryGetData<Vector2>(uid, CEContainerSlotVisuals.Offset, out var offset, appearance);
+            if (zPhysics != null)
+            {
+                // CE Z-level rendering owns the whole-sprite offset each frame. Compose with its
+                // canonical baseline instead of racing the pre/post-animation pipeline.
+                var targetDefault = state.CleanOffset + offset;
+                var delta = targetDefault - zPhysics.SpriteOffsetDefault;
+                zPhysics.SpriteOffsetDefault = targetDefault;
+                _sprite.SetOffset((uid, sprite), sprite.Offset + delta);
+            }
+            else
+            {
+                _sprite.SetOffset((uid, sprite), state.CleanOffset + offset);
+            }
+
+            state.Pending = false;
+        }
+
+        if (state.OriginalRotation is not { } originalRotation || HasComp<RotationVisualsComponent>(uid))
+            return;
+
+        _appearance.TryGetData<Angle>(uid, CEContainerSlotVisuals.Rotation, out var rotation, appearance);
+        var target = originalRotation + rotation;
+        if (sprite.Rotation != target)
+            _sprite.SetRotation((uid, sprite), target);
+    }
+
+    private void Restore(EntityUid uid, CEContainerSlotVisualStateComponent state)
+    {
+        if (state.OriginalSprite is { } originalSprite &&
+            TryComp<SpriteComponent>(uid, out var sprite) &&
+            ReferenceEquals(originalSprite, sprite))
+        {
+            Restore(uid, sprite, state);
+            return;
+        }
+
+        if (state.OriginalZPhysics is { } originalZPhysics &&
+            TryComp<CEZPhysicsComponent>(uid, out var zPhysics) &&
+            ReferenceEquals(originalZPhysics, zPhysics))
+        {
+            zPhysics.SpriteOffsetDefault = state.CleanOffset;
+        }
+
+        ClearOriginal(state);
+    }
+
+    private void Restore(EntityUid uid, SpriteComponent sprite, CEContainerSlotVisualStateComponent state)
+    {
+        if (!ReferenceEquals(state.OriginalSprite, sprite))
+            return;
+
+        if (state.OriginalZPhysics != null &&
+            TryComp<CEZPhysicsComponent>(uid, out var zPhysics) &&
+            ReferenceEquals(state.OriginalZPhysics, zPhysics))
+        {
+            var delta = state.CleanOffset - zPhysics.SpriteOffsetDefault;
+            zPhysics.SpriteOffsetDefault = state.CleanOffset;
+            _sprite.SetOffset((uid, sprite), sprite.Offset + delta);
+        }
+        else
+        {
+            _sprite.SetOffset((uid, sprite), state.CleanOffset);
+        }
+
+        if (state.OriginalRotation is { } originalRotation && !HasComp<RotationVisualsComponent>(uid))
+            _sprite.SetRotation((uid, sprite), originalRotation);
+
+        ClearOriginal(state);
+    }
+
+    private static void ClearOriginal(CEContainerSlotVisualStateComponent state)
+    {
+        state.OriginalSprite = null;
+        state.OriginalZPhysics = null;
+        state.CleanOffset = default;
+        state.OriginalRotation = null;
+    }
+}

--- a/Content.IntegrationTests/Tests/_CE/CEOpenContainerTest.cs
+++ b/Content.IntegrationTests/Tests/_CE/CEOpenContainerTest.cs
@@ -1,0 +1,221 @@
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Shared._CE.Containers;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
+using Content.Shared.Lock;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests._CE;
+
+[TestFixture]
+public sealed class CEOpenContainerTest : GameTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: CEContainerTestShelf
+  components:
+  - type: ItemSlots
+    slots:
+      first:
+        swap: false
+        ejectOnRemove: true
+        insertSound: null
+        ejectSound: null
+      second:
+        swap: false
+        ejectOnRemove: true
+        insertSound: null
+        ejectSound: null
+  - type: CEOpenContainer
+    containers: [first, second]
+  - type: CEContainerSlotVisuals
+    slots:
+      first: { offset: '-0.25,0.125', rotation: 30 }
+      second: { offset: '0.25,-0.125', rotation: 60 }
+
+- type: entity
+  id: CEContainerTestStorage
+  components:
+  - type: Storage
+    grid: ['0,0,2,2']
+  - type: CEOpenContainer
+    containers: [storagebase]
+
+- type: entity
+  id: CEContainerTestItem
+  components:
+  - type: Item
+  - type: Appearance
+
+- type: entity
+  id: CEContainerTestActor
+  components:
+  - type: Hands
+    hands:
+      hand:
+        location: Middle
+    sortedHands: [hand]
+  - type: CEContainerTransferTest
+";
+
+    [Test]
+    public async Task OpenContentsRespectSlotLocksAndNestedHosts()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var containers = Server.System<SharedContainerSystem>();
+            var slots = Server.System<ItemSlotsSystem>();
+            var access = Server.System<CEOpenContainerSystem>();
+            var interaction = Server.System<SharedInteractionSystem>();
+            var actor = SEntMan.SpawnEntity(null, map.GridCoords);
+            var shelf = SEntMan.SpawnEntity("CEContainerTestShelf", map.GridCoords);
+            var item = SEntMan.SpawnEntity("CEContainerTestItem", map.GridCoords);
+            Assert.That(slots.TryGetSlot(shelf, "first", out var first), Is.True);
+            Assert.That(slots.TryInsert(shelf, first!, item, null), Is.True);
+            Assert.That(interaction.IsAccessible(actor, item), Is.True);
+
+            SEntMan.AddComponent<LockComponent>(shelf);
+            Assert.That(interaction.IsAccessible(actor, item), Is.False);
+            Server.System<LockSystem>().Unlock(shelf, null);
+            Assert.That(interaction.IsAccessible(actor, item), Is.True);
+
+            slots.SetLock((shelf, SEntMan.GetComponent<ItemSlotsComponent>(shelf)), first!, true);
+            Assert.That(access.CanAccessContents(actor, first!.ContainerSlot!), Is.False);
+            Assert.That(interaction.IsAccessible(actor, item), Is.False);
+            slots.SetLock((shelf, SEntMan.GetComponent<ItemSlotsComponent>(shelf)), first!, false);
+
+            var outer = SEntMan.SpawnEntity(null, map.GridCoords);
+            var outerContainer = containers.EnsureContainer<Container>(outer, "outer");
+            Assert.That(containers.Insert(shelf, outerContainer), Is.True);
+            Assert.That(access.CanAccessContents(actor, first.ContainerSlot!), Is.False);
+            Assert.That(interaction.IsAccessible(actor, item), Is.False);
+            Assert.That(containers.Remove(shelf, outerContainer), Is.True);
+            Assert.That(interaction.IsAccessible(actor, item), Is.True);
+
+            // The policy also supports ordinary Storage, with no shelf layout or husbandry component.
+            var storage = SEntMan.SpawnEntity("CEContainerTestStorage", map.GridCoords);
+            var stored = SEntMan.SpawnEntity("CEContainerTestItem", map.GridCoords);
+            Assert.That(containers.TryGetContainer(storage, "storagebase", out var storageContainer), Is.True);
+            Assert.That(containers.Insert(stored, storageContainer!), Is.True);
+            Assert.That(interaction.IsAccessible(actor, stored), Is.True);
+            SEntMan.RemoveComponent<CEOpenContainerComponent>(storage);
+            Assert.That(interaction.IsAccessible(actor, stored), Is.False);
+        });
+        await Pair.RunTicksSync(5);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task RemovingShelfOrSlotOwnerPreservesItems(bool removeComponent)
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var containers = Server.System<SharedContainerSystem>();
+            var slots = Server.System<ItemSlotsSystem>();
+            var appearance = Server.System<SharedAppearanceSystem>();
+            var shelf = SEntMan.SpawnEntity("CEContainerTestShelf", map.GridCoords);
+            var firstItem = SEntMan.SpawnEntity("CEContainerTestItem", map.GridCoords);
+            var secondItem = SEntMan.SpawnEntity("CEContainerTestItem", map.GridCoords);
+            Assert.That(slots.TryInsert((shelf, null), "first", firstItem, null), Is.True);
+            Assert.That(slots.TryInsert((shelf, null), "second", secondItem, null), Is.True);
+            Assert.That(appearance.TryGetData<Vector2>(secondItem, CEContainerSlotVisuals.Offset, out var offset), Is.True);
+            Assert.That(offset, Is.EqualTo(new Vector2(0.25f, -0.125f)));
+            Assert.That(SEntMan.GetComponent<TransformComponent>(secondItem).LocalPosition, Is.EqualTo(Vector2.Zero));
+
+            Assert.That(slots.TryGetSlot(shelf, "first", out var first), Is.True);
+            Assert.That(containers.Remove(firstItem, first!.ContainerSlot!), Is.True);
+            Assert.That(appearance.TryGetData<Vector2>(secondItem, CEContainerSlotVisuals.Offset, out offset), Is.True);
+            Assert.That(offset, Is.EqualTo(new Vector2(0.25f, -0.125f)), "Removing another item must not reassign this slot.");
+
+            if (removeComponent)
+                SEntMan.RemoveComponent<ItemSlotsComponent>(shelf);
+            else
+                SEntMan.DeleteEntity(shelf);
+
+            Assert.That(SEntMan.EntityExists(secondItem), Is.True);
+            Assert.That(containers.IsEntityInContainer(secondItem), Is.False);
+            Assert.That(appearance.TryGetData<bool>(secondItem, CEContainerSlotVisuals.Active, out var active), Is.True);
+            Assert.That(active, Is.False);
+        });
+        await Pair.RunTicksSync(5);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task RejectedTransferReportsFailureAndDoesNotLoseHeldItem(bool blockRestoration)
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var hands = Server.System<SharedHandsSystem>();
+            var slots = Server.System<ItemSlotsSystem>();
+            var containers = Server.System<SharedContainerSystem>();
+            var actor = SEntMan.SpawnEntity("CEContainerTestActor", map.GridCoords);
+            var shelf = SEntMan.SpawnEntity("CEContainerTestShelf", map.GridCoords);
+            var item = SEntMan.SpawnEntity("CEContainerTestItem", map.GridCoords);
+            Assert.That(slots.TryInsertEmpty(shelf, item, actor), Is.False, "A player transfer requires a held item.");
+            Assert.That(hands.TryPickup(actor, item, "hand"), Is.True);
+            var interference = SEntMan.GetComponent<CEContainerTransferTestComponent>(actor);
+            interference.Destination = shelf;
+            interference.BlockRestoration = blockRestoration;
+            interference.Armed = true;
+
+            Assert.That(slots.TryGetSlot(shelf, "first", out var first), Is.True);
+            Assert.That(slots.TryInsertFromHand(shelf, first!, actor), Is.False);
+            Assert.That(SEntMan.EntityExists(item), Is.True);
+            Assert.That(first!.Item, Is.Not.Null);
+            Assert.That(first.Item, Is.Not.EqualTo(item));
+            Assert.That(hands.IsHolding(actor, item), Is.EqualTo(!blockRestoration));
+            Assert.That(containers.IsEntityInContainer(item), Is.EqualTo(!blockRestoration));
+        });
+        await Pair.RunTicksSync(5);
+    }
+}
+
+/// <summary>Test-only callback interference between the hand precheck and actual insertion.</summary>
+[RegisterComponent]
+public sealed partial class CEContainerTransferTestComponent : Component
+{
+    public EntityUid Destination;
+    public bool Armed;
+    public bool BlockRestoration;
+    public bool Dropped;
+}
+
+public sealed partial class CEContainerTransferTestSystem : EntitySystem
+{
+    [Dependency] private SharedContainerSystem _containers = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<CEContainerTransferTestComponent, EntRemovedFromContainerMessage>(OnRemoved);
+        SubscribeLocalEvent<CEContainerTransferTestComponent, ContainerIsInsertingAttemptEvent>(OnInserting);
+    }
+
+    private void OnRemoved(Entity<CEContainerTransferTestComponent> ent, ref EntRemovedFromContainerMessage args)
+    {
+        if (!ent.Comp.Armed)
+            return;
+        ent.Comp.Armed = false;
+        ent.Comp.Dropped = true;
+        var blocker = SpawnAtPosition("CEContainerTestItem", Transform(ent.Comp.Destination).Coordinates);
+        _containers.TryGetContainer(ent.Comp.Destination, "first", out var destination);
+        _containers.Insert(blocker, destination!);
+    }
+
+    private void OnInserting(Entity<CEContainerTransferTestComponent> ent, ref ContainerIsInsertingAttemptEvent args)
+    {
+        if (ent.Comp.Dropped && ent.Comp.BlockRestoration)
+            args.Cancel();
+    }
+}

--- a/Content.Server/_CE/Containers/CEContainerSlotVisualsComponent.cs
+++ b/Content.Server/_CE/Containers/CEContainerSlotVisualsComponent.cs
@@ -1,0 +1,21 @@
+using System.Numerics;
+
+namespace Content.Server._CE.Containers;
+
+/// <summary>Authored presentation keyed by existing container IDs. ItemSlots owns the containers.</summary>
+[RegisterComponent]
+public sealed partial class CEContainerSlotVisualsComponent : Component
+{
+    [DataField(required: true)]
+    public Dictionary<string, CEContainerSlotVisual> Slots = new();
+}
+
+[DataDefinition]
+public sealed partial class CEContainerSlotVisual
+{
+    [DataField(required: true)]
+    public Vector2 Offset;
+
+    [DataField]
+    public Angle Rotation;
+}

--- a/Content.Server/_CE/Containers/CEContainerSlotVisualsSystem.cs
+++ b/Content.Server/_CE/Containers/CEContainerSlotVisualsSystem.cs
@@ -1,0 +1,76 @@
+using Content.Shared._CE.Containers;
+using Robust.Shared.Containers;
+
+namespace Content.Server._CE.Containers;
+
+/// <summary>Displays existing container occupants without changing their physical transforms.</summary>
+public sealed partial class CEContainerSlotVisualsSystem : EntitySystem
+{
+    [Dependency] private SharedAppearanceSystem _appearance = default!;
+    [Dependency] private SharedContainerSystem _containers = default!;
+
+    [SubscribeLocalEvent]
+    private void OnStartup(Entity<CEContainerSlotVisualsComponent> ent, ref ComponentStartup args) => Refresh(ent);
+
+    [SubscribeLocalEvent]
+    private void OnMapInit(Entity<CEContainerSlotVisualsComponent> ent, ref MapInitEvent args) => Refresh(ent);
+
+    private void Refresh(Entity<CEContainerSlotVisualsComponent> ent)
+    {
+        foreach (var (id, visual) in ent.Comp.Slots)
+        {
+            if (!_containers.TryGetContainer(ent, id, out var container))
+                continue;
+
+            container.ShowContents = true;
+            container.OccludesLight = false;
+            foreach (var occupant in container.ContainedEntities)
+                Apply(occupant, visual);
+        }
+    }
+
+    [SubscribeLocalEvent]
+    private void OnShutdown(Entity<CEContainerSlotVisualsComponent> ent, ref ComponentShutdown args)
+    {
+        foreach (var id in ent.Comp.Slots.Keys)
+        {
+            if (!_containers.TryGetContainer(ent, id, out var container))
+                continue;
+            foreach (var occupant in container.ContainedEntities)
+                Clear(occupant);
+        }
+    }
+
+    [SubscribeLocalEvent]
+    private void OnInserted(Entity<CEContainerSlotVisualsComponent> ent, ref EntInsertedIntoContainerMessage args)
+    {
+        if (args.Container.Owner != ent.Owner || !ent.Comp.Slots.TryGetValue(args.Container.ID, out var visual))
+            return;
+
+        args.Container.ShowContents = true;
+        args.Container.OccludesLight = false;
+        Apply(args.Entity, visual);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnRemoved(Entity<CEContainerSlotVisualsComponent> ent, ref EntRemovedFromContainerMessage args)
+    {
+        // Removal is reported before reparenting; the message identifies the slot being left.
+        if (args.Container.Owner == ent.Owner && ent.Comp.Slots.ContainsKey(args.Container.ID))
+            Clear(args.Entity);
+    }
+
+    private void Apply(EntityUid occupant, CEContainerSlotVisual visual)
+    {
+        var appearance = EnsureComp<AppearanceComponent>(occupant);
+        _appearance.SetData(occupant, CEContainerSlotVisuals.Offset, visual.Offset, appearance);
+        _appearance.SetData(occupant, CEContainerSlotVisuals.Rotation, visual.Rotation, appearance);
+        _appearance.SetData(occupant, CEContainerSlotVisuals.Active, true, appearance);
+    }
+
+    private void Clear(EntityUid occupant)
+    {
+        if (TryComp<AppearanceComponent>(occupant, out var appearance))
+            _appearance.SetData(occupant, CEContainerSlotVisuals.Active, false, appearance);
+    }
+}

--- a/Content.Shared/Containers/ItemSlots/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlots/ItemSlotsComponent.cs
@@ -195,6 +195,11 @@ public sealed partial class ItemSlot
     [NonSerialized]
     public bool EjectOnBreak;
 
+    // CrystallEdge: exposed shelves release their items when their owner or slot component is removed.
+    [DataField, NonSerialized]
+    public bool EjectOnRemove;
+    // CrystallEdge end
+
     /// <summary>
     /// The popup shown when a standard insertion interaction uses an item rejected by this slot's filters.
     /// </summary>

--- a/Content.Shared/Containers/ItemSlots/ItemSlotsSystem.Insert.cs
+++ b/Content.Shared/Containers/ItemSlots/ItemSlotsSystem.Insert.cs
@@ -16,8 +16,16 @@ public sealed partial class ItemSlotsSystem
         EntityUid? user,
         bool excludeUserAudio = false)
     {
-        if (slot.ContainerSlot == null || !_containers.Insert(item, slot.ContainerSlot))
+        // CrystallEdge: held items use the checked hands transfer without a floor-drop interaction.
+        if (slot.ContainerSlot == null)
             return false;
+
+        var inserted = user is { } actor && _handsSystem.IsHolding(actor, item)
+            ? _handsSystem.TryDropIntoContainer(actor, item, slot.ContainerSlot)
+            : _containers.Insert(item, slot.ContainerSlot);
+        if (!inserted || !slot.ContainerSlot.Contains(item))
+            return false;
+        // CrystallEdge end
 
         if (user != null)
         {
@@ -112,7 +120,7 @@ public sealed partial class ItemSlotsSystem
     /// Tries to insert the item in a user's active hand into a specific slot.
     /// </summary>
     /// <remarks>
-    /// If insertion fails after the item is dropped, the item remains dropped.
+    /// Failed transfers try to restore the original hand through normal pickup checks. // CrystallEdge
     /// </remarks>
     /// <returns>True only if the held item was dropped and inserted.</returns>
     public bool TryInsertFromHand(EntityUid uid,
@@ -129,9 +137,7 @@ public sealed partial class ItemSlotsSystem
         if (!CanInsert(uid, slot, held.Value, user))
             return false;
 
-        if (!_handsSystem.TryDrop(user, user.Comp.ActiveHandId!))
-            return false;
-
+        // CrystallEdge: Insert owns the single checked hand transfer.
         return Insert(uid, slot, held.Value, user, excludeUserAudio: excludeUserAudio);
     }
 
@@ -154,6 +160,10 @@ public sealed partial class ItemSlotsSystem
         if (!Resolve(ent, ref ent.Comp, false))
             return false;
 
+        // CrystallEdge: a player request cannot move an item that is no longer held.
+        if (user is { } actor && !_handsSystem.IsHolding(actor, item))
+            return false;
+
         if (!TryGetAvailableSlot(ent,
                 item,
                 user,
@@ -161,9 +171,7 @@ public sealed partial class ItemSlotsSystem
                 emptyOnly: true))
             return false;
 
-        if (user != null && !_handsSystem.TryDrop(user.Value, item))
-            return false;
-
+        // CrystallEdge: Insert owns the single checked hand transfer.
         return Insert(ent, itemSlot, item, user, excludeUserAudio: excludeUserAudio);
     }
 

--- a/Content.Shared/Containers/ItemSlots/ItemSlotsSystem.Interactions.cs
+++ b/Content.Shared/Containers/ItemSlots/ItemSlotsSystem.Interactions.cs
@@ -59,7 +59,7 @@ public sealed partial class ItemSlotsSystem
         if (args.Handled)
             return;
 
-        if (!TryComp(args.User, out HandsComponent? hands))
+        if (!TryComp(args.User, out HandsComponent? hands) || !_handsSystem.IsHolding(args.User, args.Used)) // CrystallEdge
             return;
 
         if (ent.Comp.Slots.Count == 0)
@@ -98,15 +98,17 @@ public sealed partial class ItemSlotsSystem
             return;
         }
 
-        if (!_handsSystem.TryDrop(args.User, args.Used))
-            return;
-
         slots.Sort(SortEmpty);
 
         foreach (var slot in slots)
         {
             if (slot.Item != null)
+            {
+                // CrystallEdge: only a swap needs a free hand before the displaced item is picked up.
+                if (!_handsSystem.TryDrop(args.User, args.Used))
+                    return;
                 _handsSystem.TryPickupAnyHand(args.User, slot.Item.Value, handsComp: hands);
+            }
 
             if (!Insert(ent, slot, args.Used, args.User, excludeUserAudio: true))
                 return;

--- a/Content.Shared/Containers/ItemSlots/ItemSlotsSystem.Lock.cs
+++ b/Content.Shared/Containers/ItemSlots/ItemSlotsSystem.Lock.cs
@@ -52,7 +52,13 @@ public sealed partial class ItemSlotsSystem
         if (!Resolve(ent, ref ent.Comp))
             return;
 
+        // CrystallEdge: availability consumers only need actual lock transitions.
+        if (slot.Locked == locked)
+            return;
+
         slot.Locked = locked;
         Dirty(ent);
+        NotifySlotsChanged(ent);
+        // CrystallEdge end
     }
 }

--- a/Content.Shared/Containers/ItemSlots/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlots/ItemSlotsSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared._CE.Containers; // CrystallEdge: native slot availability notification.
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Destructible;
@@ -8,6 +9,7 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
 
@@ -26,6 +28,7 @@ public sealed partial class ItemSlotsSystem : EntitySystem
     [Dependency] private SharedAudioSystem _audioSystem = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private ISerializationManager _serializationManager = default!;
+    [Dependency] private INetManager _net = default!; // CrystallEdge: authoritative opt-in removal ejection.
 
     /// <summary>
     /// Spawn in starting items for any item slots that should have one.
@@ -69,6 +72,46 @@ public sealed partial class ItemSlotsSystem : EntitySystem
         EjectOnBreak(ent);
     }
 
+    // CrystallEdge: opt-in release belongs to the native slot owner, not the visual layout.
+    [SubscribeLocalEvent]
+    private void OnSlotOwnerTerminating(Entity<ItemSlotsComponent> ent, ref EntityTerminatingEvent args) => EjectOnRemove(ent);
+
+    [SubscribeLocalEvent]
+    private void OnSlotsShutdown(Entity<ItemSlotsComponent> ent, ref ComponentShutdown args)
+    {
+        EjectOnRemove(ent);
+        NotifySlotsChanged(ent);
+    }
+
+    // CrystallEdge: the backing containers are initialized before component startup.
+    [SubscribeLocalEvent]
+    private void OnSlotsStartup(Entity<ItemSlotsComponent> ent, ref ComponentStartup args) => NotifySlotsChanged(ent);
+
+    private void NotifySlotsChanged(EntityUid uid)
+    {
+        var ev = new CEItemSlotsChangedEvent();
+        RaiseLocalEvent(uid, ref ev);
+    }
+
+    private void EjectOnRemove(Entity<ItemSlotsComponent> ent)
+    {
+        if (!_net.IsServer || !TryComp(ent, out TransformComponent? transform) ||
+            transform.MapUid is not { } map || TerminatingOrDeleted(map) ||
+            transform.GridUid is { } grid && TerminatingOrDeleted(grid))
+            return;
+
+        // Removal callbacks can change slot registrations; only touch the same live canonical container.
+        foreach (var slot in new List<ItemSlot>(ent.Comp.Slots.Values))
+        {
+            if (!slot.EjectOnRemove || slot.ContainerSlot is not { ContainedEntity: { } occupant } container ||
+                !_containers.TryGetContainer(ent, container.ID, out var current) || !ReferenceEquals(current, container))
+                continue;
+
+            _containers.Remove(occupant, container, force: true);
+        }
+    }
+    // CrystallEdge end
+
     /// <summary>
     /// Eject items from slots configured to do so when the entity is broken or destroyed.
     /// </summary>
@@ -85,12 +128,14 @@ public sealed partial class ItemSlotsSystem : EntitySystem
         var startingItem = target.StartingItem;
         var ejectOnDeconstruct = target.EjectOnDeconstruct;
         var ejectOnBreak = target.EjectOnBreak;
+        var ejectOnRemove = target.EjectOnRemove; // CrystallEdge
 
         _serializationManager.CopyTo(source, ref target, notNullableOverride: true);
 
         target.StartingItem = startingItem;
         target.EjectOnDeconstruct = ejectOnDeconstruct;
         target.EjectOnBreak = ejectOnBreak;
+        target.EjectOnRemove = ejectOnRemove; // CrystallEdge
     }
 
     /// <summary>

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -176,8 +176,23 @@ public abstract partial class SharedHandsSystem
             return false;
 
         DoDrop(ent, hand, false);
-        ContainerSystem.Insert(entity, targetContainer);
-        return true;
+        // CrystallEdge: drop callbacks may change or reject the destination. Report the actual transfer.
+        if (TerminatingOrDeleted(entity) || IsHolding(ent, entity))
+            return false;
+
+        if (!TerminatingOrDeleted(targetContainer.Owner) &&
+            ContainerSystem.TryGetContainer(targetContainer.Owner, targetContainer.ID, out var current) &&
+            ReferenceEquals(current, targetContainer) &&
+            ContainerSystem.Insert(entity, targetContainer) && targetContainer.Contains(entity))
+            return true;
+
+        // Restore only a free item through normal pickup checks; do not undo other callbacks' ownership.
+        if (!TerminatingOrDeleted(ent) && !TerminatingOrDeleted(entity) &&
+            !ContainerSystem.IsEntityInContainer(entity))
+            TryPickup(ent, entity, hand, checkActionBlocker, animate: false);
+
+        return false;
+        // CrystallEdge end
     }
 
     /// <summary>

--- a/Content.Shared/_CE/Containers/CEContainerSlotVisuals.cs
+++ b/Content.Shared/_CE/Containers/CEContainerSlotVisuals.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CE.Containers;
+
+/// <summary>
+/// Networked appearance data for presenting a contained entity in an authored fixed slot.
+/// Physical transforms remain at the canonical container-local origin.
+/// </summary>
+[Serializable, NetSerializable]
+public enum CEContainerSlotVisuals : byte
+{
+    Active,
+    Offset,
+    Rotation,
+}

--- a/Content.Shared/_CE/Containers/CEItemSlotsChangedEvent.cs
+++ b/Content.Shared/_CE/Containers/CEItemSlotsChangedEvent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._CE.Containers;
+
+/// <summary>
+/// The native slot owner started, finished shutdown ejection, or changed a slot lock.
+/// Consumers read the owner's current component lifecycle and slot state.
+/// Occupant changes continue to use the native container messages.
+/// </summary>
+[ByRefEvent]
+public readonly struct CEItemSlotsChangedEvent;

--- a/Content.Shared/_CE/Containers/CEOpenContainerComponent.cs
+++ b/Content.Shared/_CE/Containers/CEOpenContainerComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CE.Containers;
+
+/// <summary>Allows direct interaction with the named containers of an exposed world fixture.</summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CEOpenContainerComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public List<string> Containers = new();
+}

--- a/Content.Shared/_CE/Containers/CEOpenContainerSystem.cs
+++ b/Content.Shared/_CE/Containers/CEOpenContainerSystem.cs
@@ -1,0 +1,49 @@
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Interaction;
+using Content.Shared.Lock;
+using Content.Shared.Storage.Components;
+using Robust.Shared.Containers;
+
+namespace Content.Shared._CE.Containers;
+
+/// <summary>Shares the same container access policy between discovery and normal interaction.</summary>
+public sealed partial class CEOpenContainerSystem : EntitySystem
+{
+    [Dependency] private SharedContainerSystem _containers = default!;
+    [Dependency] private SharedInteractionSystem _interaction = default!;
+    [Dependency] private ItemSlotsSystem _itemSlots = default!;
+
+    /// <summary>
+    /// Grants container accessibility only. Range, obstruction, ingestion and pickup checks remain native.
+    /// An opted-in fixture becomes private again while carried, worn, or nested inside another container.
+    /// </summary>
+    public bool CanAccessContents(EntityUid user, BaseContainer container)
+    {
+        var host = container.Owner;
+        if (TerminatingOrDeleted(host) ||
+            !TryComp<CEOpenContainerComponent>(host, out var open) ||
+            !open.Containers.Contains(container.ID) ||
+            !_containers.TryGetContainer(host, container.ID, out var current) ||
+            !ReferenceEquals(current, container) ||
+            _containers.IsEntityOrParentInContainer(host) ||
+            TryComp<LockComponent>(host, out var locking) && locking.Locked ||
+            TryComp<EntityStorageComponent>(host, out var storage) && !storage.Open ||
+            TryComp<ItemSlotsComponent>(host, out var slots) &&
+            _itemSlots.TryGetSlot((host, slots), container.ID, out var slot) && slot.Locked)
+            return false;
+
+        return _interaction.CanAccess(user, host);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnAccessibleOverride(Entity<TransformComponent> ent, ref AccessibleOverrideEvent args)
+    {
+        if (args.Handled || args.Target != ent.Owner ||
+            !_containers.TryGetContainingContainer(ent.Owner, out var container) ||
+            !CanAccessContents(args.User, container))
+            return;
+
+        args.Accessible = true;
+        args.Handled = true;
+    }
+}


### PR DESCRIPTION
## About the PR

Открытые стойки должны показывать и предоставлять доступ к предметам в обычных контейнерах. Добавлены явно подключаемые политика доступа и отображение по ID штатных ItemSlots; отказ переноса предмета из руки теперь возвращает неуспех.

## Why / Balance

Общая механика вынесена из животноводства для отдельного ревью, согласно [правилам разделения PR](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#content).

Основание: #455. Сначала предыдущие PR должны пройти ревью и войти в master; затем этот PR следует переназначить на master и перепроверить diff. Не объединять его в ветку предыдущего PR: это смешает области ревью.

## Technical details

15 файлов, +706/−14 строк. Содержимым владеют ItemSlots/ContainerSlot. Закрытый, заблокированный, вложенный или переносимый контейнер не становится доступным через CEOpenContainer. Sprite offsets учитывают поворот, PVS и Z-смещение. Малое CEItemSlotsChangedEvent сообщает об изменении штатного владельца; создание продуктов к нему не привязано. Прототипов кормушек и гнёзд здесь нет.

## Test plan

`CEOpenContainerTest`: блокировки и вложенность, отказ вставки из руки, удаление слотов/стойки с сохранением предметов. На итоговой композиции также проверены поворот, выход из PVS и возврат, Z-смещение и удаление владельцев в одном графическом клиенте.

Сборка Content.IntegrationTests (DebugOpt, включая Server/Client) этого промежуточного checkout прошла отдельно. Названные тесты запускались в итоговой композиции A–G: 36/36 Passed, без пропусков; это не заявление об отдельном запуске всего набора на каждой промежуточной ветке. Для воспроизведения: собрать Content.IntegrationTests и запустить названную fixture; для итогового игрового сценария нужен контент #430.

## Media

Графические наблюдения относятся к общей проверенной композиции. Новые изображения к этому PR пока не приложены.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have tested this pull request and written instructions on how to test it.
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

ItemSlots и Hands сообщают фактический результат передачи. CEOpenContainer и CEContainerSlotVisuals подключаются явно через данные прототипа.
