### PR TITLE
GOAP: поиск Edible и питание через штатный Ingestion

### DIFF
--- a/Content.IntegrationTests/Tests/_CE/CEDirectConsumptionTest.cs
+++ b/Content.IntegrationTests/Tests/_CE/CEDirectConsumptionTest.cs
@@ -1,0 +1,240 @@
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._CE.GOAP.Consumption;
+using Content.Server._CE.GOAP.Selectors;
+using Content.Shared._CE.EntityConditions.Conditions;
+using Content.Shared._CE.GOAP;
+using Content.Shared._CE.GOAP.Consumption;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.FixedPoint;
+using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Whitelist;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests._CE;
+
+[TestFixture]
+public sealed class CEDirectConsumptionTest : GameTest
+{
+    [TestPrototypes]
+    private const string Prototypes = """
+- type: Tag
+  id: CEDirectConsumptionTestFood
+
+- type: entity
+  id: CEDirectConsumptionTestConsumer
+  parent: MobHuman
+  components:
+  - type: CEGOAP
+    startSleeping: true
+
+- type: entity
+  id: CEDirectConsumptionTestFood
+  components:
+  - type: Item
+    size: Tiny
+  - type: Tag
+    tags: [CEDirectConsumptionTestFood]
+  - type: CEFoodTag
+    tags: [CEWheat]
+  - type: Solution
+    id: food
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Nutriment
+        Quantity: 5
+  - type: Edible
+    solution: food
+    delay: 0.2
+    transferAmount: 5
+    destroyOnEmpty: false
+    utensil: None
+
+- type: entity
+  id: CEDirectConsumptionTestDrink
+  parent: CEDirectConsumptionTestFood
+  components:
+  - type: Solution
+    id: food
+    solution:
+      maxVol: 20
+      reagents:
+      - ReagentId: Water
+        Quantity: 5
+  - type: Edible
+    edible: Drink
+
+- type: entity
+  id: CEDirectConsumptionTestContainer
+  components:
+  - type: ItemSlots
+    slots:
+      food: {}
+  - type: CEOpenContainer
+    containers: [food]
+""";
+
+    [Test]
+    public async Task SelectsActualContainedFoodAndRespectsSlotAccess()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var consumer = SpawnConsumer(map.GridCoords);
+            var loose = SpawnFood(map.GridCoords.Offset(new Vector2(2, 0)));
+            var contained = SpawnFood(map.GridCoords.Offset(new Vector2(0.5f, 0)));
+            var holder = SEntMan.SpawnEntity("CEDirectConsumptionTestContainer", map.GridCoords.Offset(new Vector2(0.5f, 0)));
+            var slots = SEntMan.System<ItemSlotsSystem>();
+            Assert.That(slots.TryInsert(holder, "food", contained, null), Is.True);
+
+            var selector = new CEGOAPSelectorEdible { Range = 5 };
+            Assert.That(selector.Resolve(consumer, SEntMan).Entity, Is.EqualTo(contained));
+            slots.SetLock(holder, "food", true);
+            Assert.That(selector.Resolve(consumer, SEntMan).Entity, Is.EqualTo(loose));
+            slots.SetLock(holder, "food", false);
+            Assert.That(selector.Resolve(consumer, SEntMan).Entity, Is.EqualTo(contained));
+        });
+    }
+
+    [Test]
+    public async Task PreferencesDoNotChangeDigestibilityAndDrinksUseCurrentSolution()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var consumer = SpawnConsumer(map.GridCoords);
+            var food = SpawnFood(map.GridCoords.Offset(new Vector2(0.5f, 0)));
+            var selector = new CEGOAPSelectorEdible { Range = 5, AllowedFoodTags = ["CEWheat"] };
+            Assert.That(selector.Resolve(consumer, SEntMan).Entity, Is.EqualTo(food));
+            selector.ForbiddenFoodTags.Add("CEWheat");
+            Assert.That(selector.Resolve(consumer, SEntMan).Entity, Is.Null);
+            Assert.That(SEntMan.System<IngestionSystem>().CanIngest(consumer, food), Is.True);
+
+            var drink = SEntMan.SpawnEntity("CEDirectConsumptionTestDrink", map.GridCoords.Offset(new Vector2(0.5f, 0)));
+            var waterSelector = new CEGOAPSelectorEdible
+            {
+                Range = 5,
+                Edible = IngestionSystem.Drink,
+                SolutionConditions = [new CEReagentFractionCondition { Reagent = "Water", MinFraction = 0.5f }],
+            };
+            Assert.That(waterSelector.Resolve(consumer, SEntMan).Entity, Is.EqualTo(drink));
+            var solutions = SEntMan.System<SharedSolutionContainerSystem>();
+            Assert.That(solutions.TryGetSolution(drink, "food", out var solution), Is.True);
+            Assert.That(solutions.TryAddSolution(solution.Value, new Solution("Nutriment", 10)), Is.True);
+            Assert.That(waterSelector.Resolve(consumer, SEntMan).Entity, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task GenericSelectorKeepsStartedTargetWhenCloserFoodAppears()
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid consumer = default;
+        EntityUid original = default;
+        EntityUid closer = default;
+        var action = ConsumeAction();
+        await Server.WaitAssertion(() =>
+        {
+            consumer = SpawnConsumer(map.GridCoords);
+            original = SpawnFood(map.GridCoords.Offset(new Vector2(0.8f, 0)));
+            action.RaiseStartup(consumer, SEntMan);
+            closer = SpawnFood(map.GridCoords.Offset(new Vector2(0.2f, 0)));
+            Assert.That(action.Selector!.Resolve(consumer, SEntMan).Entity, Is.EqualTo(closer));
+            Assert.That(action.RaiseUpdate(consumer, 0.1f, SEntMan), Is.EqualTo(CEGOAPActionStatus.Running));
+        });
+
+        await Server.WaitRunTicks(30);
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(Volume(original), Is.EqualTo(FixedPoint2.Zero));
+            Assert.That(Volume(closer), Is.EqualTo(FixedPoint2.New(5)));
+            Assert.That(action.RaiseUpdate(consumer, 0.1f, SEntMan), Is.EqualTo(CEGOAPActionStatus.Finished));
+            action.RaiseShutdown(consumer, SEntMan);
+        });
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task CancellationAndComponentShutdownDoNotConsumeFood(bool removeComponent)
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid food = default;
+        await Server.WaitAssertion(() =>
+        {
+            var consumer = SpawnConsumer(map.GridCoords);
+            food = SpawnFood(map.GridCoords.Offset(new Vector2(0.5f, 0)));
+            var action = ConsumeAction();
+            action.RaiseStartup(consumer, SEntMan);
+            Assert.That(action.RaiseUpdate(consumer, 0.1f, SEntMan), Is.EqualTo(CEGOAPActionStatus.Running));
+            if (removeComponent)
+                SEntMan.RemoveComponent<CEGOAPConsumeComponent>(consumer);
+            else
+                action.RaiseShutdown(consumer, SEntMan);
+        });
+
+        await Server.WaitRunTicks(30);
+        await Server.WaitAssertion(() => Assert.That(Volume(food), Is.EqualTo(FixedPoint2.New(5))));
+    }
+
+    [Test]
+    public async Task ConcurrentConsumersShareOneNativePortionWithoutDuplicateSuccess()
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid first = default;
+        EntityUid second = default;
+        EntityUid food = default;
+        var action = ConsumeAction();
+        await Server.WaitAssertion(() =>
+        {
+            first = SpawnConsumer(map.GridCoords);
+            second = SpawnConsumer(map.GridCoords);
+            food = SpawnFood(map.GridCoords.Offset(new Vector2(0.5f, 0)));
+            action.RaiseStartup(first, SEntMan);
+            action.RaiseStartup(second, SEntMan);
+            Assert.That(action.RaiseUpdate(first, 0.1f, SEntMan), Is.EqualTo(CEGOAPActionStatus.Running));
+            Assert.That(action.RaiseUpdate(second, 0.1f, SEntMan), Is.EqualTo(CEGOAPActionStatus.Running));
+        });
+
+        await Server.WaitRunTicks(30);
+        await Server.WaitAssertion(() =>
+        {
+            var firstStatus = action.RaiseUpdate(first, 0.1f, SEntMan);
+            var secondStatus = action.RaiseUpdate(second, 0.1f, SEntMan);
+            Assert.That(Volume(food), Is.EqualTo(FixedPoint2.Zero));
+            Assert.That(new[] { firstStatus, secondStatus }, Is.EquivalentTo(new[]
+            {
+                CEGOAPActionStatus.Finished,
+                CEGOAPActionStatus.Failed,
+            }));
+            action.RaiseShutdown(first, SEntMan);
+            action.RaiseShutdown(second, SEntMan);
+        });
+    }
+
+    private EntityUid SpawnConsumer(EntityCoordinates coordinates)
+        => SEntMan.SpawnEntity("CEDirectConsumptionTestConsumer", coordinates);
+
+    private EntityUid SpawnFood(EntityCoordinates coordinates)
+        => SEntMan.SpawnEntity("CEDirectConsumptionTestFood", coordinates);
+
+    private FixedPoint2 Volume(EntityUid food)
+    {
+        Assert.That(SEntMan.System<SharedSolutionContainerSystem>().TryGetSolution(food, "food", out _, out var solution), Is.True);
+        return solution!.Volume;
+    }
+
+    private static CEGOAPConsumeAction ConsumeAction() => new()
+    {
+        RetryDelay = TimeSpan.FromSeconds(2),
+        // Deliberately use a general selector: consuming must not downcast it to an edible selector.
+        Selector = new CEGOAPSelectorNearestEntity
+        {
+            Range = 5,
+            Whitelist = new EntityWhitelist { Tags = ["CEDirectConsumptionTestFood"] },
+        },
+    };
+}

--- a/Content.Server/_CE/GOAP/Consumption/CEGOAPConsumeActionSystem.cs
+++ b/Content.Server/_CE/GOAP/Consumption/CEGOAPConsumeActionSystem.cs
@@ -1,0 +1,194 @@
+using Content.Server._CE.GOAP.Navigation;
+using Content.Shared._CE.GOAP;
+using Content.Shared._CE.GOAP.Components;
+using Content.Shared._CE.GOAP.Consumption;
+using Content.Shared.DoAfter;
+using Content.Shared.FixedPoint;
+using Content.Shared.Interaction;
+using Content.Shared.Nutrition;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.Analyzers;
+using Robust.Shared.Timing;
+
+namespace Content.Server._CE.GOAP.Consumption;
+
+/// <summary>
+/// Performs one native ingestion operation on the selected edible. IngestionSystem
+/// owns the DoAfter, solution transfer and needs; this system owns only GOAP lifecycle.
+/// </summary>
+public sealed partial class CEGOAPConsumeActionSystem : CEGOAPActionSystem<CEGOAPConsumeAction>
+{
+    [Dependency] private CEGOAPTargetBackoffSystem _backoff = default!;
+    [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private IngestionSystem _ingestion = default!;
+    [Dependency] private SharedInteractionSystem _interaction = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    protected override void OnCanExecute(
+        Entity<CEGOAPComponent> ent,
+        ref CEGOAPActionCanExecuteEvent<CEGOAPConsumeAction> args)
+    {
+        if (args.Action.RetryDelay < TimeSpan.Zero)
+        {
+            args.CanExecute = false;
+            return;
+        }
+
+        if (TryComp<CEGOAPConsumeRetryComponent>(ent, out var retry))
+        {
+            if (retry.UntilByAction.TryGetValue(args.Action, out var until) && _timing.CurTime < until)
+            {
+                args.CanExecute = false;
+                return;
+            }
+
+            retry.UntilByAction.Remove(args.Action);
+        }
+
+        if (!TryResolveEdible(ent.Owner, args.Action, out _))
+            args.CanExecute = false;
+    }
+
+    protected override void OnActionStartup(
+        Entity<CEGOAPComponent> ent,
+        ref CEGOAPActionStartupEvent<CEGOAPConsumeAction> args)
+    {
+        var state = EnsureComp<CEGOAPConsumeComponent>(ent);
+        state.Phase = CEGOAPConsumePhase.Failed;
+        state.Target = null;
+        if (!TryResolveEdible(ent.Owner, args.Action, out var target))
+            return;
+
+        // A newly appearing closer food must not redirect an in-progress bite.
+        state.Target = target;
+        state.Phase = CEGOAPConsumePhase.Acquiring;
+    }
+
+    protected override void OnActionUpdate(
+        Entity<CEGOAPComponent> ent,
+        ref CEGOAPActionUpdateEvent<CEGOAPConsumeAction> args)
+    {
+        if (!TryComp<CEGOAPConsumeComponent>(ent, out var state))
+        {
+            args.Status = CEGOAPActionStatus.Failed;
+            return;
+        }
+
+        args.Target = state.Target;
+        switch (state.Phase)
+        {
+            case CEGOAPConsumePhase.Acquiring:
+                if (state.Target is not { } target || !Exists(target) ||
+                    !_interaction.InRangeAndAccessible(ent.Owner, target))
+                {
+                    if (state.Target is { } rejected)
+                        _backoff.Reject(ent.Owner, rejected);
+                    state.Phase = CEGOAPConsumePhase.Failed;
+                    args.Status = CEGOAPActionStatus.Failed;
+                    return;
+                }
+
+                // Set this before TryIngest, which can finish a zero-delay bite immediately.
+                state.Phase = CEGOAPConsumePhase.Consuming;
+                if (!_ingestion.TryIngest(ent.Owner, target))
+                {
+                    _backoff.Reject(ent.Owner, target);
+                    state.Phase = CEGOAPConsumePhase.Failed;
+                    args.Status = CEGOAPActionStatus.Failed;
+                }
+                return;
+
+            case CEGOAPConsumePhase.Consuming:
+                if (state.Target is { } active && Exists(active))
+                    return;
+
+                state.Phase = CEGOAPConsumePhase.Failed;
+                args.Status = CEGOAPActionStatus.Failed;
+                return;
+
+            case CEGOAPConsumePhase.Finished:
+                var refresh = new CEGOAPSensorRefreshEvent();
+                RaiseLocalEvent(ent.Owner, ref refresh);
+                args.Status = CEGOAPActionStatus.Finished;
+                return;
+
+            default:
+                args.Status = CEGOAPActionStatus.Failed;
+                return;
+        }
+    }
+
+    protected override void OnActionShutdown(
+        Entity<CEGOAPComponent> ent,
+        ref CEGOAPActionShutdownEvent<CEGOAPConsumeAction> args)
+    {
+        if (!TryComp<CEGOAPConsumeComponent>(ent, out var state))
+            return;
+
+        CancelEating(ent.Owner, state);
+        if (state.Phase != CEGOAPConsumePhase.Finished && args.Action.RetryDelay > TimeSpan.Zero)
+        {
+            var retry = EnsureComp<CEGOAPConsumeRetryComponent>(ent);
+            retry.UntilByAction[args.Action] = _timing.CurTime + args.Action.RetryDelay;
+        }
+
+        RemComp<CEGOAPConsumeComponent>(ent);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnIngesting(Entity<CEGOAPConsumeComponent> ent, ref IngestingEvent args)
+    {
+        if (ent.Comp.Phase == CEGOAPConsumePhase.Consuming && ent.Comp.Target == args.Food)
+            ent.Comp.Phase = args.Split.Volume > FixedPoint2.Zero
+                ? CEGOAPConsumePhase.Finished
+                : CEGOAPConsumePhase.Failed;
+    }
+
+    [SubscribeLocalEvent(after: [typeof(IngestionSystem)])]
+    private void OnEatingDoAfter(Entity<CEGOAPConsumeComponent> ent, ref EatingDoAfterEvent args)
+    {
+        if (ent.Comp.Target != args.Target)
+            return;
+
+        // One bite per action; the refreshed needs sensor decides whether another is needed.
+        args.Repeat = false;
+        if (ent.Comp.Phase == CEGOAPConsumePhase.Consuming)
+            ent.Comp.Phase = CEGOAPConsumePhase.Failed;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnConsumptionShutdown(Entity<CEGOAPConsumeComponent> ent, ref ComponentShutdown args)
+    {
+        CancelEating(ent.Owner, ent.Comp);
+    }
+
+    private void CancelEating(EntityUid consumer, CEGOAPConsumeComponent state)
+    {
+        if (state.Phase != CEGOAPConsumePhase.Consuming || state.Target is not { } target ||
+            !TryComp<DoAfterComponent>(consumer, out var doAfters))
+            return;
+
+        foreach (var doAfter in doAfters.DoAfters.Values)
+        {
+            if (doAfter.Cancelled || doAfter.Completed || doAfter.Args.Target != target ||
+                doAfter.Args.Event is not EatingDoAfterEvent)
+                continue;
+
+            _doAfter.Cancel(consumer, doAfter.Index, doAfters);
+            return;
+        }
+    }
+
+    private bool TryResolveEdible(EntityUid consumer, CEGOAPConsumeAction action, out EntityUid target)
+    {
+        target = default;
+        if (action.Selector?.Resolve(consumer, EntityManager).Entity is not { } selected ||
+            !HasComp<EdibleComponent>(selected) || !_interaction.IsAccessible(consumer, selected) ||
+            !_ingestion.CanIngest(consumer, selected) || !_ingestion.CanConsume(consumer, selected))
+            return false;
+
+        target = selected;
+        return true;
+    }
+}

--- a/Content.Server/_CE/GOAP/Consumption/CEGOAPConsumptionComponents.cs
+++ b/Content.Server/_CE/GOAP/Consumption/CEGOAPConsumptionComponents.cs
@@ -1,0 +1,24 @@
+using Content.Shared._CE.GOAP.Consumption;
+
+namespace Content.Server._CE.GOAP.Consumption;
+
+[RegisterComponent]
+public sealed partial class CEGOAPConsumeComponent : Component
+{
+    public CEGOAPConsumePhase Phase;
+    public EntityUid? Target;
+}
+
+[RegisterComponent]
+public sealed partial class CEGOAPConsumeRetryComponent : Component
+{
+    public readonly Dictionary<CEGOAPConsumeAction, TimeSpan> UntilByAction = new();
+}
+
+public enum CEGOAPConsumePhase : byte
+{
+    Acquiring,
+    Consuming,
+    Finished,
+    Failed,
+}

--- a/Content.Server/_CE/GOAP/Selectors/CEGOAPSelectorEdible.cs
+++ b/Content.Server/_CE/GOAP/Selectors/CEGOAPSelectorEdible.cs
@@ -1,0 +1,158 @@
+using System.Numerics;
+using Content.Server._CE.GOAP.Navigation;
+using Content.Server.Nutrition.Components;
+using Content.Shared._CE.Containers;
+using Content.Shared._CE.Cooking.Components;
+using Content.Shared._CE.Cooking.Prototypes;
+using Content.Shared._CE.GOAP.Selectors;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.EntityConditions;
+using Content.Shared.Interaction;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Nutrition.Prototypes;
+using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._CE.GOAP.Selectors;
+
+/// <summary>
+/// Selects an ordinary edible, including accessible contents of an open container.
+/// Preferences narrow AI selection; they do not change physical digestibility.
+/// </summary>
+[DataDefinition]
+public sealed partial class CEGOAPSelectorEdible
+    : CEGOAPTargetSelectorBase<CEGOAPSelectorEdible>, ICEGOAPTargetBackoffSelector
+{
+    [DataField(required: true)]
+    public float Range;
+
+    [DataField]
+    public ProtoId<EdiblePrototype> Edible = IngestionSystem.Food;
+
+    [DataField]
+    public HashSet<ProtoId<CEFoodTagPrototype>> AllowedFoodTags = new();
+
+    [DataField]
+    public HashSet<ProtoId<CEFoodTagPrototype>> ForbiddenFoodTags = new();
+
+    /// <summary>Optional conditions on the edible's solution, e.g. water fraction.</summary>
+    [DataField]
+    public EntityCondition[]? SolutionConditions;
+}
+
+public sealed partial class CEGOAPSelectorEdibleSystem : CEGOAPTargetSelectorSystem<CEGOAPSelectorEdible>
+{
+    [Dependency] private CEGOAPTargetBackoffSystem _backoff = default!;
+    [Dependency] private CEOpenContainerSystem _openContainers = default!;
+    [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private IngestionSystem _ingestion = default!;
+    [Dependency] private SharedContainerSystem _containers = default!;
+    [Dependency] private SharedEntityConditionsSystem _conditions = default!;
+    [Dependency] private SharedInteractionSystem _interaction = default!;
+    [Dependency] private SharedSolutionContainerSystem _solutions = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+
+    protected override void Resolve(ref CEGOAPSelectorResolveEvent<CEGOAPSelectorEdible> ev)
+    {
+        var selector = ev.Selector;
+        if (!float.IsFinite(selector.Range) || selector.Range < 0f ||
+            !TryComp(ev.Agent, out TransformComponent? origin))
+            return;
+
+        var agent = ev.Agent;
+        var position = _transform.GetWorldPosition(origin);
+        var bestDistance = selector.Range * selector.Range;
+        EntityUid? best = null;
+        _backoff.Prune(agent);
+
+        void Consider(EntityUid candidate)
+        {
+            if (candidate == agent || _backoff.IsRejected(agent, candidate) ||
+                !TryComp(candidate, out TransformComponent? xform) || xform.MapID != origin.MapID)
+                return;
+
+            var distance = Vector2.DistanceSquared(position, _transform.GetWorldPosition(xform));
+            if (!float.IsFinite(distance) || distance > bestDistance ||
+                distance.Equals(bestDistance) && best is { } current && candidate.Id > current.Id ||
+                !_interaction.IsAccessible(agent, candidate) ||
+                !CanSelect(agent, candidate, selector))
+                return;
+
+            best = candidate;
+            bestDistance = distance;
+        }
+
+        foreach (var edible in _lookup.GetEntitiesInRange<EdibleComponent>(
+                     origin.Coordinates, selector.Range, LookupFlags.Uncontained))
+            Consider(edible.Owner);
+
+        // Typed edible lookup cannot discover occupants of non-edible holders.
+        // Traverse only explicit open containers; never recurse into bags or inventories.
+        foreach (var host in _lookup.GetEntitiesInRange<CEOpenContainerComponent>(
+                     origin.Coordinates, selector.Range, LookupFlags.Uncontained))
+        {
+            if (!TryComp(host.Owner, out ContainerManagerComponent? manager))
+                continue;
+
+            foreach (var container in _containers.GetAllContainers(host.Owner, manager))
+            {
+                if (!_openContainers.CanAccessContents(agent, container))
+                    continue;
+
+                foreach (var occupant in container.ContainedEntities)
+                    Consider(occupant);
+            }
+        }
+
+        if (best is not { } target)
+            return;
+
+        ev.Entity = target;
+        ev.Position = Transform(target).Coordinates;
+    }
+
+    private bool CanSelect(EntityUid consumer, EntityUid candidate, CEGOAPSelectorEdible selector)
+    {
+        if (!TryComp(candidate, out EdibleComponent? edible) ||
+            _ingestion.GetEdibleType((candidate, edible)) != selector.Edible)
+            return false;
+
+        if (selector.Edible == IngestionSystem.Food)
+        {
+            if (_ingestion.TotalNutrition((candidate, edible)) <= 0f ||
+                !HasComp<IgnoreBadFoodComponent>(consumer) && HasComp<BadFoodComponent>(candidate) ||
+                !MatchesFoodTags(candidate, selector))
+                return false;
+        }
+        else if (selector.Edible != IngestionSystem.Drink ||
+                 _ingestion.TotalHydration((candidate, edible)) <= 0f ||
+                 HasComp<BadDrinkComponent>(candidate))
+        {
+            return false;
+        }
+
+        return _ingestion.CanIngest(consumer, candidate) &&
+            _ingestion.CanConsume(consumer, candidate) &&
+            (selector.SolutionConditions == null ||
+             _solutions.TryGetSolution(candidate, edible.Solution, out var solution, out _) &&
+             _conditions.TryConditions(solution.Value.Owner, selector.SolutionConditions, consumer));
+    }
+
+    private bool MatchesFoodTags(EntityUid food, CEGOAPSelectorEdible selector)
+    {
+        if (!TryComp(food, out CEFoodTagComponent? tags))
+            return selector.AllowedFoodTags.Count == 0;
+
+        var allowed = selector.AllowedFoodTags.Count == 0;
+        foreach (var tag in tags.Tags)
+        {
+            if (selector.ForbiddenFoodTags.Contains(tag))
+                return false;
+
+            allowed |= selector.AllowedFoodTags.Contains(tag);
+        }
+
+        return allowed;
+    }
+}

--- a/Content.Shared/_CE/EntityConditions/Conditions/CEReagentFractionCondition.cs
+++ b/Content.Shared/_CE/EntityConditions/Conditions/CEReagentFractionCondition.cs
@@ -1,0 +1,63 @@
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.EntityConditions;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CE.EntityConditions.Conditions;
+
+/// <summary>
+/// Checks how much of a solution's current volume belongs to a reagent prototype.
+/// </summary>
+public sealed partial class CEReagentFractionEntityConditionSystem
+    : EntityConditionSystem<SolutionComponent, CEReagentFractionCondition>
+{
+    protected override void Condition(
+        Entity<SolutionComponent> entity,
+        ref EntityConditionEvent<CEReagentFractionCondition> args)
+    {
+        args.Result = false;
+
+        var condition = args.Condition;
+        var solution = entity.Comp.Solution;
+        if (!float.IsFinite(condition.MinFraction) ||
+            !float.IsFinite(condition.MaxFraction) ||
+            condition.MinFraction < 0f ||
+            condition.MaxFraction > 1f ||
+            condition.MinFraction > condition.MaxFraction ||
+            solution.Volume <= 0)
+        {
+            return;
+        }
+
+        var reagentVolume = solution.GetTotalPrototypeQuantity(condition.Reagent);
+        foreach (var reagent in condition.AdditionalReagents)
+        {
+            if (reagent != condition.Reagent)
+                reagentVolume += solution.GetTotalPrototypeQuantity(reagent);
+        }
+        var fraction = reagentVolume.Float() / solution.Volume.Float();
+        args.Result = fraction >= condition.MinFraction && fraction <= condition.MaxFraction;
+    }
+}
+
+/// <summary>
+/// A reusable solution-composition condition. Fractions are inclusive and use the current
+/// solution volume rather than the container capacity.
+/// </summary>
+public sealed partial class CEReagentFractionCondition : EntityConditionBase<CEReagentFractionCondition>
+{
+    [DataField(required: true)]
+    public ProtoId<ReagentPrototype> Reagent;
+
+    /// <summary>Other explicitly permitted reagents contributing to the same fraction.</summary>
+    [DataField]
+    public HashSet<ProtoId<ReagentPrototype>> AdditionalReagents = new();
+
+    [DataField(required: true)]
+    public float MinFraction;
+
+    [DataField]
+    public float MaxFraction = 1f;
+
+    public override string EntityConditionGuidebookText(IPrototypeManager prototype) => string.Empty;
+}

--- a/Content.Shared/_CE/GOAP/Consumption/CEGOAPConsumeAction.cs
+++ b/Content.Shared/_CE/GOAP/Consumption/CEGOAPConsumeAction.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared._CE.GOAP.Consumption;
+
+/// <summary>
+/// Consumes the selected edible through the canonical ingestion system.
+/// Movement remains a separate GOAP action.
+/// </summary>
+[DataDefinition]
+public sealed partial class CEGOAPConsumeAction : CEGOAPActionBase<CEGOAPConsumeAction>
+{
+    [DataField(required: true)]
+    public TimeSpan RetryDelay;
+}


### PR DESCRIPTION
## About the PR

NPC выбирает конкретный съедобный предмет на полу или в доступном открытом контейнере и употребляет его через IngestionSystem. Поиск учитывает пищевые предпочтения и текущий раствор; конкуренция и отмена не должны давать повторный успешный приём пищи.

## Why / Balance

Общая механика вынесена из животноводства для отдельного ревью, согласно [правилам разделения PR](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#content).

Основание: #456. Сначала предыдущие PR должны пройти ревью и войти в master; затем этот PR следует переназначить на master и перепроверить diff. Не объединять его в ветку предыдущего PR: это смешает области ревью.

## Technical details

6 файлов, +691 строка. Ingestion, DoAfter и Satiation остаются владельцами употребления и насыщения. Новый слой отвечает за выбор цели и состояние действия GOAP. Отдельного протокола источников/посредников, автоматического кормления животных и специальных компонентов кормушки нет. Зависит от Actions/GOAP и открытых контейнеров предыдущих PR.

## Test plan

`CEDirectConsumptionTest`: настоящее содержимое контейнера, ограничения доступа, неизменная начатая цель, конкурирующие потребители одной порции, отмена и shutdown, диета и фактический состав жидкости.

Сборка Content.IntegrationTests (DebugOpt, включая Server/Client) этого промежуточного checkout прошла отдельно. Названные тесты запускались в итоговой композиции A–G: 36/36 Passed, без пропусков; это не заявление об отдельном запуске всего набора на каждой промежуточной ветке. Для воспроизведения: собрать Content.IntegrationTests и запустить названную fixture; для итогового игрового сценария нужен контент #430.

## Media

Графические наблюдения относятся к общей проверенной композиции. Новые изображения к этому PR пока не приложены.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have tested this pull request and written instructions on how to test it.
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

Добавлены CEGOAPConsumeAction, CEGOAPSelectorEdible и условие состава реагентов. Животные и кормушки подключаются отдельным контентным PR.
