### PR TITLE
GOAP: бегство и защита от угроз

### DIFF
--- a/Content.IntegrationTests/Tests/_CE/CEGoapDefenseTest.cs
+++ b/Content.IntegrationTests/Tests/_CE/CEGoapDefenseTest.cs
@@ -1,0 +1,239 @@
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._CE.GOAP.Actions;
+using Content.Server._CE.GOAP.Classifiers;
+using Content.Server._CE.GOAP.Combat;
+using Content.Server._CE.NPC;
+using Content.Shared._CE.EntityEffect;
+using Content.Shared._CE.EntityEffect.Effects;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Movement.Components;
+using Content.Shared.NPC.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
+using CEDamage = Content.Shared._CE.EntityEffect.Effects.Damage;
+
+namespace Content.IntegrationTests.Tests._CE;
+
+[TestFixture]
+public sealed class CEGoapDefenseTest : GameTest
+{
+    public override PoolSettings PoolSettings => new() { Connected = false };
+
+    [TestPrototypes]
+    private const string Prototypes = """
+- type: npcFaction
+  id: CEDefenseTestFaction
+  friendly: [CEDefenseTestFaction]
+
+- type: entity
+  id: CEDefenseTestTarget
+  components:
+  - type: NpcFactionMember
+    factions: [CEDefenseTestFaction]
+  - type: Damageable
+    damageContainer: Biological
+  # Native DamageDealtEvent stores damage only on Injurable entities.
+  - type: Injurable
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      body:
+        shape: !type:PhysShapeCircle
+          radius: 0.2
+        layer: [MobLayer]
+        mask: [MobMask]
+
+- type: entity
+  id: CEDefenseTestWatcher
+  parent: CEDefenseTestTarget
+  components:
+  - type: CEGOAP
+  - type: CEGOAPEyesPerceptor
+    updateInterval: 0.1
+    crossZLevelVision: false
+  - type: CEGOAPKnowledgeCache
+  - type: CEGOAPPainPerceptor
+    retaliationDuration: 5
+  - type: CEGOAPAllyThreatPerceptor
+    range: 5
+  - type: CENPCMovement
+  - type: CombatMode
+""";
+
+    [Test]
+    public async Task StationaryVisibleAllyChangesClassificationWithoutMoving()
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid watcher = default;
+        EntityUid target = default;
+        MapCoordinates initialTargetPosition = default;
+        await Server.WaitPost(() =>
+        {
+            watcher = SpawnWatcher(map.GridCoords);
+            target = SpawnTarget(map.GridCoords.Offset(Vector2.UnitX));
+            initialTargetPosition = Server.System<SharedTransformSystem>().GetMapCoordinates(target);
+        });
+
+        await Server.WaitRunTicks(15);
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(Knowledge(watcher).Allies, Does.Contain(target));
+            Server.System<NpcFactionSystem>().AggroEntity(watcher, target);
+        });
+        await Server.WaitRunTicks(15);
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(Knowledge(watcher).Enemies, Does.Contain(target));
+            Assert.That(Knowledge(watcher).Allies, Does.Not.Contain(target));
+            // Grid traversal may change the parent without moving the entity in the world.
+            Assert.That(Server.System<SharedTransformSystem>().GetMapCoordinates(target),
+                Is.EqualTo(initialTargetPosition));
+            Server.System<NpcFactionSystem>().DeAggroEntity(watcher, target);
+        });
+        await Server.WaitRunTicks(15);
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(Knowledge(watcher).Allies, Does.Contain(target));
+            Assert.That(Knowledge(watcher).Enemies, Does.Not.Contain(target));
+        });
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task NativeArcHitsKnownThreatAndFiltersAllyOutsideCircleAction(bool defensive)
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid guard = default;
+        EntityUid aggressor = default;
+        EntityUid ally = default;
+        await Server.WaitAssertion(() =>
+        {
+            PrepareArena(map.Grid, map.Tile.Tile);
+            guard = SpawnWatcher(map.GridCoords);
+            aggressor = SpawnTarget(map.GridCoords.Offset(new Vector2(0.9f, -0.35f)));
+            ally = SpawnTarget(map.GridCoords.Offset(new Vector2(0.9f, 0.35f)));
+            if (defensive)
+                SEntMan.AddComponent<CEGOAPDefensiveCombatComponent>(guard);
+
+            // Real damage, rather than writing the knowledge cache, establishes the threat.
+            Assert.That(Server.System<DamageableSystem>().TryChangeDamage(guard, BluntDamage(), origin: aggressor), Is.True);
+            Assert.That(Knowledge(guard).Enemies, Does.Contain(aggressor));
+            Assert.That(SEntMan.HasComponent<CEGOAPCircleMeleeComponent>(guard), Is.False);
+        });
+        await Server.WaitRunTicks(1);
+        await Server.WaitAssertion(() =>
+        {
+            Swing(guard);
+            Assert.That(Damage(aggressor), Is.EqualTo(2));
+            Assert.That(Damage(ally), Is.EqualTo(defensive ? 0 : 2));
+        });
+    }
+
+    [Test]
+    public async Task LateWitnessRecognizesDefenderAndTargetsOriginalAggressor()
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid guard = default;
+        EntityUid aggressor = default;
+        EntityUid protectedAlly = default;
+        EntityUid lateWitness = default;
+        await Server.WaitAssertion(() =>
+        {
+            PrepareArena(map.Grid, map.Tile.Tile);
+            guard = SpawnWatcher(map.GridCoords);
+            SEntMan.AddComponent<CEGOAPDefensiveCombatComponent>(guard);
+            protectedAlly = SpawnTarget(map.GridCoords.Offset(-Vector2.UnitX));
+            aggressor = SpawnTarget(map.GridCoords.Offset(new Vector2(0.9f, -0.35f)));
+            Assert.That(Server.System<DamageableSystem>().TryChangeDamage(protectedAlly, BluntDamage(), origin: aggressor), Is.True);
+            Assert.That(Knowledge(guard).Enemies, Does.Contain(aggressor));
+
+            // The witness did not exist during the first hit and cannot remember its origin.
+            lateWitness = SpawnWatcher(map.GridCoords.Offset(new Vector2(0.9f, 0.35f)));
+            Assert.That(Knowledge(lateWitness).Enemies, Is.Empty);
+        });
+        await Server.WaitRunTicks(1);
+        await Server.WaitAssertion(() =>
+        {
+            Swing(guard);
+            Assert.That(Damage(aggressor), Is.EqualTo(2));
+            Assert.That(Damage(lateWitness), Is.Zero);
+            Assert.That(Damage(protectedAlly), Is.EqualTo(2));
+            Assert.That(Knowledge(lateWitness).Enemies, Does.Contain(aggressor));
+            Assert.That(Knowledge(lateWitness).Enemies, Does.Not.Contain(guard));
+            Assert.That(Knowledge(guard).Enemies, Does.Not.Contain(lateWitness));
+        });
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task UrgentActionsRestoreCalmWalkingAndPreserveExistingRotationLock(bool alreadyLocked)
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var actor = SpawnWatcher(map.GridCoords);
+            var movement = SEntMan.GetComponent<CENPCMovementComponent>(actor);
+            Assert.That(movement.Walking, Is.True);
+            var flee = new CEGOAPFleeAction();
+            flee.RaiseStartup(actor, SEntMan);
+            Assert.That(movement.Walking, Is.False);
+            flee.RaiseShutdown(actor, SEntMan);
+            Assert.That(movement.Walking, Is.True);
+
+            if (alreadyLocked)
+                SEntMan.AddComponent<NoRotateOnMoveComponent>(actor);
+            var circle = new CEGOAPCircleMeleeAction();
+            circle.RaiseStartup(actor, SEntMan);
+            Assert.That(movement.Walking, Is.False);
+            Assert.That(SEntMan.HasComponent<NoRotateOnMoveComponent>(actor), Is.True);
+            circle.RaiseShutdown(actor, SEntMan);
+            Assert.That(movement.Walking, Is.True);
+            Assert.That(SEntMan.HasComponent<NoRotateOnMoveComponent>(actor), Is.EqualTo(alreadyLocked));
+        });
+    }
+
+    private EntityUid SpawnWatcher(EntityCoordinates coords)
+        => SEntMan.SpawnEntity("CEDefenseTestWatcher", coords);
+
+    private EntityUid SpawnTarget(EntityCoordinates coords)
+        => SEntMan.SpawnEntity("CEDefenseTestTarget", coords);
+
+    private CEGOAPKnowledgeCacheComponent Knowledge(EntityUid actor)
+        => SEntMan.GetComponent<CEGOAPKnowledgeCacheComponent>(actor);
+
+    private float Damage(EntityUid actor)
+        => Server.System<DamageableSystem>().GetTotalDamage(actor).Float();
+
+    private static DamageSpecifier BluntDamage()
+    {
+        var damage = new DamageSpecifier();
+        damage.DamageDict["Blunt"] = 2;
+        return damage;
+    }
+
+    private void PrepareArena(Entity<MapGridComponent> grid, Tile tile)
+    {
+        // CreateTestMap supplies one tile; the arc scene spans both sides of its origin.
+        var maps = Server.System<SharedMapSystem>();
+        for (var x = -2; x <= 2; x++)
+        for (var y = -2; y <= 2; y++)
+            maps.SetTile(grid, new Vector2i(x, y), tile);
+    }
+
+    private void Swing(EntityUid source)
+    {
+        // Exercise the real raycast, target-filter event and native damage pipeline.
+        // No Circle action is running when this animation-equivalent keyframe lands.
+        var arc = new WeaponArcAttack
+        {
+            ArcWidth = 90,
+            Effects = [new CEDamage { DamageSpec = BluntDamage(), ColorFlash = false }],
+        };
+        arc.Effect(new CEEntityEffectArgs(SEntMan, source, null, Angle.FromWorldVec(Vector2.UnitX), 1, null, null));
+    }
+}

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Server._CE.NPC;
 using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Administration.Managers;
@@ -120,6 +121,7 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
             foreach (var (comp, mover) in EntityQuery<NPCSteeringComponent, InputMoverComponent>())
             {
                 mover.CurTickSprintMovement = Vector2.Zero;
+                mover.CurTickWalkMovement = Vector2.Zero; // CrystallEdge: clear both NPC gaits.
                 comp.PathfindToken?.Cancel();
                 comp.PathfindToken = null;
             }
@@ -210,6 +212,7 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
         if (TryComp(uid, out InputMoverComponent? controller))
         {
             controller.CurTickSprintMovement = Vector2.Zero;
+            controller.CurTickWalkMovement = Vector2.Zero; // CrystallEdge: clear both NPC gaits.
 
             var ev = new SpriteMoveEvent(false);
             RaiseLocalEvent(uid, ref ev);
@@ -288,7 +291,11 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
             Array.Clear(steering.Danger);
         }
 
-        component.CurTickSprintMovement = value;
+        // CrystallEdge: authored NPC gait must match the movement speed used by steering.
+        var walking = TryComp<CENPCMovementComponent>(uid, out var movement) && movement.Walking;
+        component.CurTickWalkMovement = walking ? value : Vector2.Zero;
+        component.CurTickSprintMovement = walking ? Vector2.Zero : value;
+        // CrystallEdge end
         component.LastInputTick = _timing.CurTick;
         component.LastInputSubTick = ushort.MaxValue;
 
@@ -339,6 +346,10 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
         var offsetRot = -_mover.GetParentGridAngle(mover);
         _modifierQuery.TryGetComponent(uid, out var modifier);
         var moveSpeed = GetSprintSpeed(uid, modifier);
+        // CrystallEdge: ordinary livestock travel uses native walk speed.
+        if (TryComp<CENPCMovementComponent>(uid, out var movement) && movement.Walking)
+            moveSpeed = modifier?.CurrentWalkSpeed ?? MovementSpeedModifierComponent.DefaultBaseWalkSpeed;
+        // CrystallEdge end
         var body = _physicsQuery.GetComponent(uid);
         var dangerPoints = steering.DangerPoints;
         dangerPoints.Clear();

--- a/Content.Server/_CE/GOAP/Actions/CEGOAPCircleMeleeActionSystem.cs
+++ b/Content.Server/_CE/GOAP/Actions/CEGOAPCircleMeleeActionSystem.cs
@@ -1,0 +1,114 @@
+using System.Numerics;
+using Content.Server._CE.MeleeWeapon;
+using Content.Server._CE.NPC;
+using Content.Server.NPC.Systems;
+using Content.Shared._CE.Animation.Item.Components;
+using Content.Shared._CE.GOAP;
+using Content.Shared._CE.GOAP.Components;
+using Content.Shared.CombatMode;
+using Content.Shared.Movement.Components;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Timing;
+
+namespace Content.Server._CE.GOAP.Actions;
+
+/// <summary>Approaches and attacks a threat while moving around it at melee distance.</summary>
+public sealed partial class CEGOAPCircleMeleeAction : CEGOAPActionBase<CEGOAPCircleMeleeAction>
+{
+    [DataField] public float OrbitRadius = 0.8f;
+    [DataField] public float AttackRange = 1f;
+    [DataField] public float PursuitRange = 10f;
+    [DataField] public TimeSpan RepathInterval = TimeSpan.FromSeconds(0.4);
+}
+
+[RegisterComponent, AutoGenerateComponentPause]
+public sealed partial class CEGOAPCircleMeleeComponent : Component
+{
+    [DataField] public bool AddedRotationLock;
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan NextRepath;
+}
+
+public sealed partial class CEGOAPCircleMeleeActionSystem : CEGOAPActionSystem<CEGOAPCircleMeleeAction>
+{
+    [Dependency] private NPCSteeringSystem _steering = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private CEWeaponSystem _weapon = default!;
+    [Dependency] private SharedCombatModeSystem _combat = default!;
+    [Dependency] private MobStateSystem _mobState = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    protected override void OnActionStartup(Entity<CEGOAPComponent> ent, ref CEGOAPActionStartupEvent<CEGOAPCircleMeleeAction> args)
+    {
+        var state = EnsureComp<CEGOAPCircleMeleeComponent>(ent);
+        state.NextRepath = TimeSpan.Zero;
+        // Orbit movement must not turn the weapon away from its target during the attack animation.
+        state.AddedRotationLock = !HasComp<NoRotateOnMoveComponent>(ent);
+        EnsureComp<NoRotateOnMoveComponent>(ent);
+        _combat.SetInCombatMode(ent, true);
+        if (TryComp<CENPCMovementComponent>(ent, out var movement))
+            movement.Walking = false;
+    }
+
+    protected override void OnActionUpdate(Entity<CEGOAPComponent> ent, ref CEGOAPActionUpdateEvent<CEGOAPCircleMeleeAction> args)
+    {
+        var result = args.Action.Selector?.Resolve(ent, EntityManager);
+        if (result?.Entity is not { } target || !Exists(target) ||
+            TryComp<MobStateComponent>(target, out var mob) && _mobState.IsIncapacitated(target, mob) ||
+            !Transform(ent).Coordinates.TryDistance(EntityManager, Transform(target).Coordinates, out var distance) ||
+            distance > args.Action.PursuitRange)
+        {
+            args.Status = CEGOAPActionStatus.Finished;
+            return;
+        }
+
+        if (!_weapon.TryGetWeapon(ent, out _))
+        {
+            args.Status = CEGOAPActionStatus.Failed;
+            return;
+        }
+
+        var origin = _transform.GetWorldPosition(ent);
+        var targetXform = Transform(target);
+        var targetPosition = _transform.GetWorldPosition(targetXform);
+        if (distance <= args.Action.AttackRange)
+            _weapon.TryUseAtTarget(ent, target, CEUseType.Primary);
+
+        var state = Comp<CEGOAPCircleMeleeComponent>(ent);
+        if (_timing.CurTime < state.NextRepath)
+            return;
+        state.NextRepath = _timing.CurTime + args.Action.RepathInterval;
+
+        EntityCoordinates destination;
+        if (distance > args.Action.OrbitRadius + 0.8f)
+        {
+            destination = targetXform.Coordinates;
+        }
+        else
+        {
+            var radial = origin - targetPosition;
+            radial = radial.LengthSquared() > 0.001f ? Vector2.Normalize(radial) : Vector2.UnitX;
+            var turn = new Angle(ent.Owner.Id % 2 == 0 ? 0.8 : -0.8);
+            var position = targetPosition + turn.RotateVec(radial) * args.Action.OrbitRadius;
+            var local = Vector2.Transform(position, _transform.GetInvWorldMatrix(targetXform.ParentUid));
+            destination = new EntityCoordinates(targetXform.ParentUid, local);
+        }
+
+        _steering.Unregister(ent);
+        _steering.Register(ent, destination).Range = 0.15f;
+    }
+
+    protected override void OnActionShutdown(Entity<CEGOAPComponent> ent, ref CEGOAPActionShutdownEvent<CEGOAPCircleMeleeAction> args)
+    {
+        _steering.Unregister(ent);
+        _combat.SetInCombatMode(ent, false);
+        if (TryComp<CENPCMovementComponent>(ent, out var movement))
+            movement.Walking = true;
+        if (TryComp<CEGOAPCircleMeleeComponent>(ent, out var state) && state.AddedRotationLock)
+            RemComp<NoRotateOnMoveComponent>(ent);
+        RemComp<CEGOAPCircleMeleeComponent>(ent);
+    }
+}

--- a/Content.Server/_CE/GOAP/Actions/CEGOAPFleeActionSystem.cs
+++ b/Content.Server/_CE/GOAP/Actions/CEGOAPFleeActionSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.NPC.Systems;
 using Content.Shared._CE.GOAP;
 using Content.Shared._CE.GOAP.Components;
 using Content.Shared.NPC;
+using Content.Server._CE.NPC;
 using Robust.Shared.Timing;
 
 namespace Content.Server._CE.GOAP.Actions;
@@ -42,6 +43,9 @@ public sealed partial class CEGOAPFleeActionSystem : CEGOAPActionSystem<CEGOAPFl
         Entity<CEGOAPComponent> ent,
         ref CEGOAPActionStartupEvent<CEGOAPFleeAction> args)
     {
+        if (TryComp<CENPCMovementComponent>(ent, out var movement))
+            movement.Walking = false;
+
         if (args.Action.Selector == null)
             return;
 
@@ -104,6 +108,8 @@ public sealed partial class CEGOAPFleeActionSystem : CEGOAPActionSystem<CEGOAPFl
     {
         _nextRecalc.Remove(ent);
         _steering.Unregister(ent);
+        if (TryComp<CENPCMovementComponent>(ent, out var movement))
+            movement.Walking = true;
     }
 
     /// <summary>

--- a/Content.Server/_CE/GOAP/Actions/CEGOAPMeleeAttackAction.cs
+++ b/Content.Server/_CE/GOAP/Actions/CEGOAPMeleeAttackAction.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Content.Server._CE.MeleeWeapon;
 using Content.Shared._CE.Animation.Item.Components;
 using Content.Shared._CE.GOAP;
@@ -6,7 +5,6 @@ using Content.Shared._CE.GOAP.Components;
 using Content.Shared.CombatMode;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
-using Robust.Shared.Random;
 
 namespace Content.Server._CE.GOAP.Actions;
 
@@ -28,12 +26,8 @@ public sealed partial class CEGOAPMeleeAttackAction : CEGOAPActionBase<CEGOAPMel
 public sealed partial class CEGOAPMeleeAttackActionSystem : CEGOAPActionSystem<CEGOAPMeleeAttackAction>
 {
     [Dependency] private CEWeaponSystem _weapon = default!;
-    [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedCombatModeSystem _combatMode = default!;
-    [Dependency] private IRobustRandom _random = default!;
     [Dependency] private MobStateSystem _mobState = default!;
-
-    [Dependency] private EntityQuery<TransformComponent> _xformQuery = default!;
 
     protected override void OnActionStartup(
         Entity<CEGOAPComponent> ent,
@@ -66,36 +60,7 @@ public sealed partial class CEGOAPMeleeAttackActionSystem : CEGOAPActionSystem<C
             return;
         }
 
-        if (!_weapon.TryGetWeapon(ent, out var weapon))
-        {
-            args.Status = CEGOAPActionStatus.Failed;
-            return;
-        }
-
-        if (!_xformQuery.TryGetComponent(ent, out var xform) ||
-            !_xformQuery.TryGetComponent(target, out var targetXform))
-        {
-            args.Status = CEGOAPActionStatus.Failed;
-            return;
-        }
-
-        if (!xform.Coordinates.TryDistance(EntityManager, targetXform.Coordinates, out var distance))
-        {
-            args.Status = CEGOAPActionStatus.Failed;
-            return;
-        }
-
-        // In range: attack
-        var ownerPos = _transform.GetWorldPosition(xform);
-        var targetPos = _transform.GetWorldPosition(targetXform);
-        var direction = targetPos - ownerPos;
-        var angle = direction == Vector2.Zero
-            ? Angle.Zero
-            : Angle.FromWorldVec(direction);
-        angle += Angle.FromDegrees(
-            _random.NextFloat(-args.Action.AngleVariation, args.Action.AngleVariation));
-
-        if (!_weapon.TryUse(ent, weapon.Value, args.Action.UseType, angle))
+        if (!_weapon.TryUseAtTarget(ent, target, args.Action.UseType, args.Action.AngleVariation))
         {
             args.Status = CEGOAPActionStatus.Failed;
             return;

--- a/Content.Server/_CE/GOAP/CEGOAPSystem.Knowledge.cs
+++ b/Content.Server/_CE/GOAP/CEGOAPSystem.Knowledge.cs
@@ -12,12 +12,14 @@ public sealed partial class CEGOAPSystem
 {
     /// <summary>
     /// Adds or refreshes a knowledge entry. Raises <see cref="CEGOAPKnowledgeUpdatedEvent"/>
-    /// when a new entity is added or its position changes.
+    /// when a new entity is added or its position changes. Batch perceptors may suppress
+    /// notification and call <see cref="RaiseKnowledgeUpdated"/> once after their scan.
     /// </summary>
     public void Remember(
         Entity<CEGOAPComponent?> ent,
         EntityUid target,
-        EntityCoordinates coords)
+        EntityCoordinates coords,
+        bool notify = true)
     {
         if (!Resolve(ent, ref ent.Comp))
             return;
@@ -33,7 +35,7 @@ public sealed partial class CEGOAPSystem
             ExpiresAt = expires,
         };
 
-        if (changed)
+        if (changed && notify)
             RaiseKnowledgeUpdated(ent);
     }
 
@@ -87,7 +89,8 @@ public sealed partial class CEGOAPSystem
         RaiseKnowledgeUpdated(ent);
     }
 
-    private void RaiseKnowledgeUpdated(EntityUid ent)
+    /// <summary>Publishes a completed perception batch, including changed relationships at unchanged positions.</summary>
+    public void RaiseKnowledgeUpdated(EntityUid ent)
     {
         var ev = new CEGOAPKnowledgeUpdatedEvent();
         RaiseLocalEvent(ent, ref ev);

--- a/Content.Server/_CE/GOAP/Classifiers/CEGOAPKnowledgeCacheSystem.cs
+++ b/Content.Server/_CE/GOAP/Classifiers/CEGOAPKnowledgeCacheSystem.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using Content.Server._CE.GOAP.Perceptors;
+using Robust.Shared.Timing;
 using Content.Shared._CE.GOAP.Components;
 using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Systems;
@@ -15,6 +18,7 @@ namespace Content.Server._CE.GOAP.Classifiers;
 public sealed partial class CEGOAPKnowledgeCacheSystem : EntitySystem
 {
     [Dependency] private NpcFactionSystem _faction = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     [Dependency] private EntityQuery<NpcFactionMemberComponent> _factionQuery = default!;
 
@@ -62,11 +66,29 @@ public sealed partial class CEGOAPKnowledgeCacheSystem : EntitySystem
         }
 
         _factionQuery.TryGetComponent(uid, out var selfFaction);
+        TryComp<CEGOAPPainPerceptorComponent>(uid, out var pain);
+        var explicitHostiles = _faction.GetHostiles(uid);
 
         foreach (var (target, _) in goap.Knowledge)
         {
             if (target == uid)
                 continue;
+
+            // Actual recent damage overrides a normally friendly faction relationship.
+            if (pain?.Attacker == target && _timing.CurTime < pain.RetaliationUntil)
+            {
+                cache.Enemies.Add(target);
+                continue;
+            }
+
+            if (_faction.IsIgnored(uid, target))
+                continue;
+
+            if (explicitHostiles.Contains(target))
+            {
+                cache.Enemies.Add(target);
+                continue;
+            }
 
             if (!_factionQuery.TryGetComponent(target, out var targetFaction))
                 continue;

--- a/Content.Server/_CE/GOAP/Combat/CEGOAPDefensiveCombatComponent.cs
+++ b/Content.Server/_CE/GOAP/Combat/CEGOAPDefensiveCombatComponent.cs
@@ -1,0 +1,5 @@
+namespace Content.Server._CE.GOAP.Combat;
+
+/// <summary>Limits autonomous melee hits to known threats, independently of the current movement action.</summary>
+[RegisterComponent]
+public sealed partial class CEGOAPDefensiveCombatComponent : Component;

--- a/Content.Server/_CE/GOAP/Combat/CEGOAPDefensiveCombatSystem.cs
+++ b/Content.Server/_CE/GOAP/Combat/CEGOAPDefensiveCombatSystem.cs
@@ -1,0 +1,34 @@
+using Content.Server._CE.GOAP.Classifiers;
+using Content.Shared._CE.MeleeWeapon;
+using Robust.Shared.Player;
+
+namespace Content.Server._CE.GOAP.Combat;
+
+public sealed partial class CEGOAPDefensiveCombatSystem : EntitySystem
+{
+    /// <summary>Lets witnesses recognize a defender even after the original provocation is no longer visible.</summary>
+    public bool IsDefendingAgainst(EntityUid attacker, EntityUid target)
+    {
+        return !HasComp<ActorComponent>(attacker) &&
+               HasComp<CEGOAPDefensiveCombatComponent>(attacker) &&
+               TryComp<CEGOAPKnowledgeCacheComponent>(attacker, out var knowledge) &&
+               knowledge.Enemies.Contains(target);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnArcTargets(Entity<CEGOAPDefensiveCombatComponent> ent, ref CEWeaponArcTargetsEvent args)
+    {
+        if (HasComp<ActorComponent>(ent))
+            return;
+
+        // The animation may finish after its GOAP action. Keep the hit policy on the actor,
+        // otherwise a finishing defensive swing can provoke nearby allies into fighting.
+        if (!TryComp<CEGOAPKnowledgeCacheComponent>(ent, out var knowledge))
+        {
+            args.Targets.Clear();
+            return;
+        }
+
+        args.Targets.RemoveAll(target => !knowledge.Enemies.Contains(target));
+    }
+}

--- a/Content.Server/_CE/GOAP/Perceptors/CEGOAPAllyThreatPerceptorSystem.cs
+++ b/Content.Server/_CE/GOAP/Perceptors/CEGOAPAllyThreatPerceptorSystem.cs
@@ -1,0 +1,51 @@
+using Content.Server._CE.GOAP.Combat;
+using Content.Server._CE.GOAP.Classifiers;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Examine;
+using Content.Shared.NPC.Systems;
+
+namespace Content.Server._CE.GOAP.Perceptors;
+
+/// <summary>Witnesses attacks against nearby allies and remembers the attacker.</summary>
+[RegisterComponent]
+public sealed partial class CEGOAPAllyThreatPerceptorComponent : Component
+{
+    [DataField] public float Range = 6f;
+}
+
+public sealed partial class CEGOAPAllyThreatPerceptorSystem : EntitySystem
+{
+    [Dependency] private CEGOAPPainPerceptorSystem _pain = default!;
+    [Dependency] private NpcFactionSystem _faction = default!;
+    [Dependency] private ExamineSystemShared _examine = default!;
+    [Dependency] private CEGOAPDefensiveCombatSystem _defense = default!;
+
+    [SubscribeLocalEvent]
+    private void OnAllyDamaged(Entity<DamageableComponent> victim, ref DamageDealtEvent args)
+    {
+        if (args.Damage.GetTotal() <= 0 || args.Origin is not { } attacker || !Exists(attacker) || attacker == victim.Owner)
+            return;
+
+        var defendingAlly = _defense.IsDefendingAgainst(attacker, victim.Owner);
+        var query = EntityQueryEnumerator<CEGOAPAllyThreatPerceptorComponent, CEGOAPPainPerceptorComponent, CEGOAPKnowledgeCacheComponent>();
+        while (query.MoveNext(out var uid, out var witness, out var pain, out var knowledge))
+        {
+            if (uid == victim.Owner || uid == attacker ||
+                knowledge.Enemies.Contains(victim.Owner) ||
+                !_faction.IsEntityFriendly(uid, victim.Owner) ||
+                !_examine.InRangeUnOccluded(uid, victim.Owner, witness.Range))
+                continue;
+
+            // A witness may arrive after the original provocation. Share a trusted NPC defender's
+            // threat instead of mistaking its restricted melee hit for aggression against an ally.
+            if (defendingAlly && _faction.IsEntityFriendly(uid, attacker))
+            {
+                _pain.ReportThreat((uid, pain), victim.Owner);
+                continue;
+            }
+
+            _pain.ReportThreat((uid, pain), attacker);
+        }
+    }
+}

--- a/Content.Server/_CE/GOAP/Perceptors/CEGOAPEyesPerceptorSystem.cs
+++ b/Content.Server/_CE/GOAP/Perceptors/CEGOAPEyesPerceptorSystem.cs
@@ -80,6 +80,8 @@ public sealed partial class CEGOAPEyesPerceptorSystem : EntitySystem
 
             eyes.NextUpdateTime = curTime + eyes.UpdateInterval;
             Scan((uid, eyes, goap));
+            // Classify once per scan, including stationary targets whose faction relationship changed.
+            _goap.RaiseKnowledgeUpdated(uid);
         }
     }
 
@@ -120,7 +122,7 @@ public sealed partial class CEGOAPEyesPerceptorSystem : EntitySystem
             if (!_examine.InRangeUnOccluded(uid, targetUid, eyes.VisionRadius + 0.5f))
                 continue;
 
-            _goap.Remember((uid, goap), targetUid, targetXform.Coordinates);
+            _goap.Remember((uid, goap), targetUid, targetXform.Coordinates, notify: false);
         }
 
         if (!eyes.CrossZLevelVision || currentMapUid == null)
@@ -172,7 +174,7 @@ public sealed partial class CEGOAPEyesPerceptorSystem : EntitySystem
                 if (!IsTileTransparentAt(currentMapUid.Value, targetWorldPos))
                     continue;
 
-                _goap.Remember((uid, goap), targetUid, targetXform.Coordinates);
+                _goap.Remember((uid, goap), targetUid, targetXform.Coordinates, notify: false);
             }
         }
 
@@ -213,7 +215,7 @@ public sealed partial class CEGOAPEyesPerceptorSystem : EntitySystem
                 if (!_examine.InRangeUnOccluded(selfOnAboveMap, targetOnAboveMap, eyes.VisionRadius + 0.5f, null))
                     continue;
 
-                _goap.Remember((uid, goap), targetUid, targetXform.Coordinates);
+                _goap.Remember((uid, goap), targetUid, targetXform.Coordinates, notify: false);
             }
         }
     }

--- a/Content.Server/_CE/GOAP/Perceptors/CEGOAPPainPerceptorSystem.cs
+++ b/Content.Server/_CE/GOAP/Perceptors/CEGOAPPainPerceptorSystem.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Timing;
 using Content.Shared._CE.GOAP.Components;
 using Content.Shared.Damage.Systems;
 using Robust.Shared.Analyzers;
@@ -8,24 +10,60 @@ namespace Content.Server._CE.GOAP.Perceptors;
 /// Pain perception. Whenever the NPC takes damage from a known source, that source is added
 /// to the knowledge store. Lets mobs react to attackers they didn't visually spot first.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, AutoGenerateComponentPause]
 public sealed partial class CEGOAPPainPerceptorComponent : Component
 {
+    /// <summary>How long an actual attacker is a threat, even if normally friendly.</summary>
+    [DataField]
+    public TimeSpan RetaliationDuration;
+
+    [DataField]
+    public EntityUid? Attacker;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan RetaliationUntil;
 }
 
 public sealed partial class CEGOAPPainPerceptorSystem : EntitySystem
 {
     [Dependency] private CEGOAPSystem _goap = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     [SubscribeLocalEvent]
     private void OnDamaged(Entity<CEGOAPPainPerceptorComponent> ent, ref DamageDealtEvent args)
     {
-        if (args.Origin is not { } source || source == ent.Owner)
+        if (args.Damage.GetTotal() <= 0 || args.Origin is not { } source || source == ent.Owner || !Exists(source))
             return;
 
+        ReportThreat(ent, source);
+    }
+
+    public void ReportThreat(Entity<CEGOAPPainPerceptorComponent> ent, EntityUid source)
+    {
         if (!TryComp<CEGOAPComponent>(ent, out var goap))
             return;
 
-        _goap.Remember((ent.Owner, goap), source, Transform(source).Coordinates);
+        if (ent.Comp.RetaliationDuration > TimeSpan.Zero)
+        {
+            ent.Comp.Attacker = source;
+            ent.Comp.RetaliationUntil = _timing.CurTime + ent.Comp.RetaliationDuration;
+        }
+
+        _goap.Remember((ent.Owner, goap), source, Transform(source).Coordinates, notify: false);
+        _goap.RaiseKnowledgeUpdated(ent.Owner);
+        goap.NextPlanTime = TimeSpan.Zero;
+    }
+
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<CEGOAPPainPerceptorComponent>();
+        while (query.MoveNext(out var uid, out var pain))
+        {
+            if (pain.Attacker is not { } attacker || _timing.CurTime < pain.RetaliationUntil)
+                continue;
+
+            pain.Attacker = null;
+            _goap.Forget(uid, attacker);
+        }
     }
 }

--- a/Content.Server/_CE/MeleeWeapon/CEWeaponSystem.cs
+++ b/Content.Server/_CE/MeleeWeapon/CEWeaponSystem.cs
@@ -1,15 +1,18 @@
+using System.Numerics;
 using Content.Server.Movement.Systems;
 using Content.Shared._CE.Animation.Item.Components;
 using Content.Shared._CE.EntityEffect.Effects;
 using Content.Shared._CE.MeleeWeapon;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
+using Robust.Shared.Random;
 
 namespace Content.Server._CE.MeleeWeapon;
 
 public sealed partial class CEWeaponSystem : CESharedWeaponSystem
 {
     [Dependency] private LagCompensationSystem _lag = default!;
+    [Dependency] private IRobustRandom _random = default!;
     private const int MaxTargets = 10;
 
     /// <summary>
@@ -22,6 +25,23 @@ public sealed partial class CEWeaponSystem : CESharedWeaponSystem
     /// Fallback validation range when no WeaponArcAttack effect is found on the weapon.
     /// </summary>
     private const float FallbackRange = 1f;
+
+    /// <summary>Uses the actor's current weapon toward an entity on the same coordinate space.</summary>
+    public bool TryUseAtTarget(EntityUid user, EntityUid target, CEUseType useType, float angleVariation = 0f)
+    {
+        if (!TryComp(user, out TransformComponent? userTransform) ||
+            !TryComp(target, out TransformComponent? targetTransform) ||
+            !userTransform.Coordinates.TryDistance(EntityManager, targetTransform.Coordinates, out _) ||
+            !TryGetWeapon(user, out var weapon))
+            return false;
+
+        var direction = TransformSystem.GetWorldPosition(targetTransform) - TransformSystem.GetWorldPosition(userTransform);
+        var angle = direction == Vector2.Zero ? Angle.Zero : Angle.FromWorldVec(direction);
+        if (angleVariation > 0f)
+            angle += Angle.FromDegrees(_random.NextFloat(-angleVariation, angleVariation));
+
+        return TryUse(user, weapon.Value, useType, angle);
+    }
 
     /// <summary>
     /// For player attacks, skip damage from the animation keyframe.

--- a/Content.Server/_CE/NPC/CENPCMovementComponent.cs
+++ b/Content.Server/_CE/NPC/CENPCMovementComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server._CE.NPC;
+
+/// <summary>Opt-in walking for NPCs. Urgent actions temporarily select sprinting.</summary>
+[RegisterComponent]
+public sealed partial class CENPCMovementComponent : Component
+{
+    [DataField]
+    public bool Walking = true;
+}

--- a/Content.Shared/_CE/EntityEffect/Effects/WeaponArcAttack.cs
+++ b/Content.Shared/_CE/EntityEffect/Effects/WeaponArcAttack.cs
@@ -170,6 +170,8 @@ public sealed partial class CEWeaponArcAttackEffectSystem : CEEntityEffectSystem
             !_interaction.InRangeUnobstructed(_args.Source, t, effectiveRange + 0.1f, overlapCheck: false));
 
         var targets = new List<EntityUid>(hitEntities);
+        var targetsEvent = new CEWeaponArcTargetsEvent(targets);
+        RaiseLocalEvent(args.Args.Source, ref targetsEvent);
 
         // Inline effects (kick, ability with no weapon slot): apply directly to each hit target.
         // Runs on both peers via the shared animation system.

--- a/Content.Shared/_CE/MeleeWeapon/Events.cs
+++ b/Content.Shared/_CE/MeleeWeapon/Events.cs
@@ -3,6 +3,10 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared._CE.MeleeWeapon;
 
+/// <summary>Raised on the attacker to narrow physically hit arc targets before effects are applied.</summary>
+[ByRefEvent]
+public readonly record struct CEWeaponArcTargetsEvent(List<EntityUid> Targets);
+
 /// <summary>
 /// Is called on the object being used to determine what animations it provides
 /// </summary>


### PR DESCRIPTION
## About the PR

Мирное движение, бегство и защитное преследование задаются поведением NPC. Защитник обходит угрозу и атакует её; поздний свидетель распознаёт исходного агрессора, а оружейная дуга не переносит ответную агрессию на союзников.

## Why / Balance

Общая механика вынесена из животноводства для отдельного ревью, согласно [правилам разделения PR](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#content).

Основание: #457. Сначала предыдущие PR должны пройти ревью и войти в master; затем этот PR следует переназначить на master и перепроверить diff. Не объединять его в ветку предыдущего PR: это смешает области ревью.

## Technical details

16 файлов, +573/−48 строк. Политика защиты хранится в компоненте, действия и восприятие — в системах GOAP. NPCSteering учитывает общую политику скорости. Нет проверок вида курицы/петуха, изменений существующих NPC-прототипов или видовой faction здесь. Положение в стеке нужно для последовательного ревью; C не является смысловой зависимостью этой механики.

## Test plan

`CEGoapDefenseTest`: поздний свидетель, стационарная цель, штатная оружейная дуга с фильтром союзника, восстановление мирной скорости и существующего rotation lock после срочного действия. Итоговая игровая сессия подтверждала бегство, обход и урон угрозе.

Сборка Content.IntegrationTests (DebugOpt, включая Server/Client) этого промежуточного checkout прошла отдельно. Названные тесты запускались в итоговой композиции A–G: 36/36 Passed, без пропусков; это не заявление об отдельном запуске всего набора на каждой промежуточной ветке. Для воспроизведения: собрать Content.IntegrationTests и запустить названную fixture; для итогового игрового сценария нужен контент #430.

## Media

Графические наблюдения относятся к общей проверенной композиции. Новые изображения к этому PR пока не приложены.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have tested this pull request and written instructions on how to test it.
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

Добавлены CEGOAPDefensiveCombat и CENPCMovement; события оружия передают действительную цель. Отдельные прототипы подключают защитное поведение явно.
