### PR TITLE
IconSmooth: отображение уровня раствора

### DIFF
--- a/Content.Client/_CE/IconSmoothing/CESolutionIconSmoothVisualsSystem.cs
+++ b/Content.Client/_CE/IconSmoothing/CESolutionIconSmoothVisualsSystem.cs
@@ -1,0 +1,73 @@
+using Content.Client.IconSmoothing;
+using Content.Shared._CE.IconSmoothing;
+using Content.Shared.Chemistry;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Rounding;
+using Robust.Client.GameObjects;
+
+namespace Content.Client._CE.IconSmoothing;
+
+/// <summary>
+/// Selects an authored IconSmooth state family from the canonical solution appearance.
+/// </summary>
+public sealed partial class CESolutionIconSmoothVisualsSystem : EntitySystem
+{
+    [Dependency] private AppearanceSystem _appearance = default!;
+    [Dependency] private IconSmoothSystem _iconSmooth = default!;
+
+    [SubscribeLocalEvent]
+    private void OnMapInit(Entity<CESolutionIconSmoothVisualsComponent> ent, ref MapInitEvent args)
+    {
+        UpdateStateBase(ent);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnAppearanceChange(
+        Entity<CESolutionIconSmoothVisualsComponent> ent,
+        ref AppearanceChangeEvent args)
+    {
+        UpdateStateBase(ent, args.Component);
+    }
+
+    private void UpdateStateBase(
+        Entity<CESolutionIconSmoothVisualsComponent> ent,
+        AppearanceComponent? appearance = null)
+    {
+        if (ent.Comp.StateBases.Count < 2
+            || !Resolve(ent.Owner, ref appearance, false)
+            || !TryComp<IconSmoothComponent>(ent, out var smooth)
+            || !TryComp<SolutionContainerVisualsComponent>(ent, out var solutionVisuals)
+            || !_appearance.TryGetData(
+                ent.Owner,
+                SolutionContainerVisuals.FillFraction,
+                out float fraction,
+                appearance))
+        {
+            return;
+        }
+
+        // A container may publish updates for several solutions. Use the same selection
+        // contract as the canonical solution visualizer, which owns the appearance data.
+        if (!string.IsNullOrEmpty(solutionVisuals.SolutionName)
+            && _appearance.TryGetData(ent.Owner, SolutionContainerVisuals.SolutionName,
+                out string solutionName, appearance)
+            && solutionName != solutionVisuals.SolutionName)
+        {
+            return;
+        }
+
+        var level = ContentHelpers.RoundToLevels(
+            Math.Clamp(fraction, 0f, 1f),
+            1,
+            ent.Comp.StateBases.Count);
+        var stateBase = ent.Comp.StateBases[level];
+
+        if (smooth.StateBase == stateBase)
+            return;
+
+        // SetStateBase recreates corner layers without removing the old ones.
+        // Recalculate the existing layers so repeated level changes do not accumulate sprites.
+        smooth.StateBase = stateBase;
+        _iconSmooth.DirtyNeighbours(ent.Owner, smooth);
+    }
+}

--- a/Content.Shared/_CE/IconSmoothing/CESolutionIconSmoothVisualsComponent.cs
+++ b/Content.Shared/_CE/IconSmoothing/CESolutionIconSmoothVisualsComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CE.IconSmoothing;
+
+/// <summary>
+/// Authored IconSmooth state families for a solution's fill levels.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CESolutionIconSmoothVisualsComponent : Component
+{
+    /// <summary>
+    /// State prefixes from empty to full, with at least one filled level.
+    /// IconSmooth appends the topology suffix; no sprite naming convention is imposed here.
+    /// </summary>
+    [DataField(required: true)]
+    public List<string> StateBases = new();
+}


### PR DESCRIPTION
## About the PR

Составной объект с IconSmooth должен менять отображаемый уровень жидкости по фактическому объёму раствора. Добавлено небольшое расширение SolutionContainerVisuals с задаваемыми в прототипе семействами состояний.

## Why / Balance

Общая механика вынесена из животноводства для отдельного ревью, согласно [правилам разделения PR](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#content).

Основание: #458. Сначала предыдущие PR должны пройти ревью и войти в master; затем этот PR следует переназначить на master и перепроверить diff. Не объединять его в ветку предыдущего PR: это смешает области ревью.

## Technical details

2 файла, +90 строк. Состояние раствора и базовое appearance остаются штатными; CE-система выбирает семейство IconSmooth. Системы животных, контейнеров и конкретные ассеты здесь не меняются. Предыдущий PR является только последовательностью стека, смысловой зависимости от защиты NPC нет.

## Test plan

Отдельный checkout собран. В итоговой композиции одним графическим клиентом проверены реальные уровни 100→75/25 и возврат сцены через PVS; накопления слоёв не наблюдалось. Отдельного автоматического визуального теста не добавлено.

Сборка Content.IntegrationTests (DebugOpt, включая Server/Client) этого промежуточного checkout прошла отдельно. Названные тесты запускались в итоговой композиции A–G: 36/36 Passed, без пропусков; это не заявление об отдельном запуске всего набора на каждой промежуточной ветке. Для воспроизведения: собрать Content.IntegrationTests и запустить названную fixture; для итогового игрового сценария нужен контент #430.

## Media

Графические наблюдения относятся к общей проверенной композиции. Новые изображения к этому PR пока не приложены.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have tested this pull request and written instructions on how to test it.
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

Опциональный CESolutionIconSmoothVisuals; конкретные state families и спрайты задаются последующим контентом.
