### PR TITLE
ItemSlots: вставка в соседние соединённые контейнеры

### DIFF
--- a/Content.IntegrationTests/Tests/_CE/CEConnectedItemSlotsTest.cs
+++ b/Content.IntegrationTests/Tests/_CE/CEConnectedItemSlotsTest.cs
@@ -1,0 +1,92 @@
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._CE.Containers;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Hands.EntitySystems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests._CE;
+
+[TestFixture]
+public sealed class CEConnectedItemSlotsTest : GameTest
+{
+    [TestPrototypes]
+    private const string Prototypes = """
+- type: entity
+  id: CEConnectedTestShelf
+  components:
+  - type: ItemSlots
+    slots:
+      first: { swap: false, insertSound: null, ejectSound: null }
+      second: { swap: false, insertSound: null, ejectSound: null }
+  - type: CEConnectedItemSlots
+    group: shelf
+    node: storage
+  - type: NodeContainer
+    nodes:
+      storage:
+        !type:AdjacentNode
+        nodeGroupID: Default
+- type: entity
+  id: CEConnectedTestItem
+  components:
+  - type: Item
+- type: entity
+  id: CEConnectedTestActor
+  components:
+  - type: Hands
+    hands:
+      hand:
+        location: Middle
+    sortedHands: [hand]
+""";
+
+    [Test]
+    public async Task ConnectedInsertionUsesCardinalNeighboursAndNativeSlots()
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid origin = default;
+        EntityUid north = default;
+        EntityUid east = default;
+        EntityUid actor = default;
+        await Server.WaitAssertion(() =>
+        {
+            var maps = Server.System<SharedMapSystem>();
+            maps.SetTile(map.Grid.Owner, map.Grid.Comp, new Vector2i(0, 1), map.Tile.Tile);
+            maps.SetTile(map.Grid.Owner, map.Grid.Comp, new Vector2i(1, 0), map.Tile.Tile);
+            origin = SEntMan.SpawnEntity("CEConnectedTestShelf", map.GridCoords);
+            north = SEntMan.SpawnEntity("CEConnectedTestShelf", map.GridCoords.Offset(new Vector2(0, 1)));
+            east = SEntMan.SpawnEntity("CEConnectedTestShelf", map.GridCoords.Offset(new Vector2(1, 0)));
+            actor = SEntMan.SpawnEntity("CEConnectedTestActor", map.GridCoords);
+            var transform = Server.System<SharedTransformSystem>();
+            transform.AnchorEntity(origin, SEntMan.GetComponent<TransformComponent>(origin));
+            transform.AnchorEntity(north, SEntMan.GetComponent<TransformComponent>(north));
+            transform.AnchorEntity(east, SEntMan.GetComponent<TransformComponent>(east));
+            var slots = Server.System<ItemSlotsSystem>();
+            Assert.That(slots.TryInsert((origin, null), "first", SEntMan.SpawnEntity("CEConnectedTestItem", map.GridCoords), null), Is.True);
+            Assert.That(slots.TryInsert((origin, null), "second", SEntMan.SpawnEntity("CEConnectedTestItem", map.GridCoords), null), Is.True);
+        });
+        await Pair.RunTicksSync(10);
+        await Server.WaitAssertion(() =>
+        {
+            var hands = Server.System<SharedHandsSystem>();
+            var connected = Server.System<CEConnectedItemSlotsSystem>();
+            var item = SEntMan.SpawnEntity("CEConnectedTestItem", map.GridCoords);
+            Assert.That(hands.TryPickup(actor, item, "hand"), Is.True);
+            Assert.That(connected.TryInsertFromHand(actor, item, origin, out var destination), Is.True);
+            Assert.That(destination, Is.EqualTo(north));
+            Server.System<SharedTransformSystem>().Unanchor(north, SEntMan.GetComponent<TransformComponent>(north));
+        });
+        await Pair.RunTicksSync(10);
+        await Server.WaitAssertion(() =>
+        {
+            var item = SEntMan.SpawnEntity("CEConnectedTestItem", map.GridCoords);
+            Assert.That(Server.System<SharedHandsSystem>().TryPickup(actor, item, "hand"), Is.True);
+            Assert.That(Server.System<CEConnectedItemSlotsSystem>().TryInsertFromHand(actor, item, origin, out var destination), Is.True);
+            Assert.That(destination, Is.EqualTo(east));
+        });
+        await Pair.RunTicksSync(5);
+    }
+
+}

--- a/Content.Server/_CE/Containers/CEConnectedItemSlotsComponent.cs
+++ b/Content.Server/_CE/Containers/CEConnectedItemSlotsComponent.cs
@@ -1,0 +1,20 @@
+namespace Content.Server._CE.Containers;
+
+/// <summary>
+/// Marks an ordinary item-slot fixture as part of a cardinally connected insertion group.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CEConnectedItemSlotsComponent : Component
+{
+    /// <summary>
+    /// Only cardinally adjacent hosts with the same group belong to one network.
+    /// </summary>
+    [DataField(required: true)]
+    public string Group = string.Empty;
+
+    /// <summary>
+    /// The node name in <see cref="Content.Shared.NodeContainer.NodeContainerComponent"/> used for connectivity.
+    /// </summary>
+    [DataField(required: true)]
+    public string Node = string.Empty;
+}

--- a/Content.Server/_CE/Containers/CEConnectedItemSlotsSystem.cs
+++ b/Content.Server/_CE/Containers/CEConnectedItemSlotsSystem.cs
@@ -1,0 +1,159 @@
+using System.Numerics;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
+using Content.Shared.NodeContainer;
+
+namespace Content.Server._CE.Containers;
+
+/// <summary>Routes held items to nearby connected item-slot fixtures after local insertion is exhausted.</summary>
+public sealed partial class CEConnectedItemSlotsSystem : EntitySystem
+{
+    [Dependency] private ItemSlotsSystem _slots = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
+
+    [SubscribeLocalEvent]
+    private void OnAfterInteractUsing(Entity<CEConnectedItemSlotsComponent> ent, ref AfterInteractUsingEvent args)
+    {
+        if (!args.Handled && args.CanReach && TryInsertFromHand(args.User, args.Used, ent.Owner, out _))
+            args.Handled = true;
+    }
+
+    public bool TryInsertFromHand(EntityUid user, EntityUid item, EntityUid origin, out EntityUid destination)
+    {
+        destination = default;
+        foreach (var candidate in GetMembersByDistance(origin))
+        {
+            // A failed transfer can leave an item outside if normal pickup restoration is blocked.
+            if (!_hands.IsHolding(user, item))
+                return false;
+            if (!_slots.TryInsertEmpty(candidate, item, user))
+                continue;
+
+            destination = candidate;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the connected group in deterministic breadth-first order.
+    /// </summary>
+    private IReadOnlyList<EntityUid> GetMembersByDistance(EntityUid origin)
+    {
+        var result = new List<EntityUid>();
+        if (TerminatingOrDeleted(origin) ||
+            !TryComp<CEConnectedItemSlotsComponent>(origin, out var connected) ||
+            !HasComp<ItemSlotsComponent>(origin))
+            return result;
+
+        result.Add(origin);
+        if (!TryComp<NodeContainerComponent>(origin, out var nodes) ||
+            !nodes.Nodes.TryGetValue(connected.Node, out var originNode))
+            return result;
+
+        var pending = new Queue<Node>();
+        var visited = new HashSet<EntityUid> { origin };
+        pending.Enqueue(originNode);
+
+        while (pending.TryDequeue(out var current))
+        {
+            foreach (var neighbour in GetNeighbours(current, connected.Group, connected.Node))
+            {
+                if (!visited.Add(neighbour.Owner))
+                    continue;
+
+                result.Add(neighbour.Owner);
+                pending.Enqueue(neighbour);
+            }
+        }
+
+        return result;
+    }
+
+    private IReadOnlyList<Node> GetNeighbours(Node current, string group, string nodeName)
+    {
+        var candidates = new List<ConnectedNeighbour>();
+        if (!TryComp(current.Owner, out TransformComponent? currentTransform) ||
+            !currentTransform.Anchored ||
+            currentTransform.GridUid is not { } gridUid)
+            return Array.Empty<Node>();
+
+        foreach (var candidate in current.ReachableNodes)
+        {
+            if (candidate.Owner == current.Owner || TerminatingOrDeleted(candidate.Owner) ||
+                !HasComp<ItemSlotsComponent>(candidate.Owner) ||
+                !TryComp<CEConnectedItemSlotsComponent>(candidate.Owner, out var connected) ||
+                !string.Equals(connected.Group, group, StringComparison.Ordinal) ||
+                !string.Equals(connected.Node, nodeName, StringComparison.Ordinal) ||
+                !string.Equals(candidate.Name, nodeName, StringComparison.Ordinal) ||
+                !TryComp<NodeContainerComponent>(candidate.Owner, out var candidateNodes) ||
+                !candidateNodes.Nodes.TryGetValue(nodeName, out var configuredNode) ||
+                !ReferenceEquals(configuredNode, candidate) ||
+                !TryComp(candidate.Owner, out TransformComponent? candidateTransform) ||
+                !candidateTransform.Anchored ||
+                candidateTransform.GridUid != gridUid ||
+                !TryGetCardinalDirection(
+                    candidateTransform.LocalPosition - currentTransform.LocalPosition,
+                    out var direction))
+                continue;
+
+            candidates.Add(new ConnectedNeighbour(candidate, direction));
+        }
+
+        candidates.Sort(static (left, right) =>
+        {
+            var direction = left.Direction.CompareTo(right.Direction);
+            return direction != 0
+                ? direction
+                : left.Node.Owner.CompareTo(right.Node.Owner);
+        });
+
+        var result = new Node[candidates.Count];
+        for (var i = 0; i < candidates.Count; i++)
+            result[i] = candidates[i].Node;
+
+        return result;
+    }
+
+    private static bool TryGetCardinalDirection(Vector2 delta, out CardinalDirection direction)
+    {
+        const float tolerance = 0.001f;
+        if (MathF.Abs(delta.X) <= tolerance && MathF.Abs(delta.Y - 1f) <= tolerance)
+        {
+            direction = CardinalDirection.North;
+            return true;
+        }
+
+        if (MathF.Abs(delta.X) <= tolerance && MathF.Abs(delta.Y + 1f) <= tolerance)
+        {
+            direction = CardinalDirection.South;
+            return true;
+        }
+
+        if (MathF.Abs(delta.X - 1f) <= tolerance && MathF.Abs(delta.Y) <= tolerance)
+        {
+            direction = CardinalDirection.East;
+            return true;
+        }
+
+        if (MathF.Abs(delta.X + 1f) <= tolerance && MathF.Abs(delta.Y) <= tolerance)
+        {
+            direction = CardinalDirection.West;
+            return true;
+        }
+
+        direction = default;
+        return false;
+    }
+
+    private enum CardinalDirection
+    {
+        North,
+        South,
+        East,
+        West,
+    }
+
+    private readonly record struct ConnectedNeighbour(Node Node, CardinalDirection Direction);
+}


### PR DESCRIPTION
## About the PR

Предмет, который не помещается в выбранную секцию стойки, можно вставить в доступную соседнюю секцию. Обход соединённых контейнеров выбирает ближайшие секции и вызывает штатную вставку ItemSlots.

## Why / Balance

Общая механика вынесена из животноводства для отдельного ревью, согласно [правилам разделения PR](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#content).

Основание: #459. Сначала предыдущие PR должны пройти ревью и войти в master; затем этот PR следует переназначить на master и перепроверить diff. Не объединять его в ветку предыдущего PR: это смешает области ревью.

## Technical details

3 файла, +271 строка, из них 92 строки теста. Возможность подключается компонентом и не зависит от животноводства. Не владеет содержимым и не создаёт предметы. Требует исправленного фактического результата переноса ItemSlots/Hands из PR открытых контейнеров; порядок после визуального PR сохраняет проверенный стек.

## Test plan

`CEConnectedItemSlotsTest`: соединение по сторонам, раздельные группы и переход к свободному штатному слоту. Проверки отказа переноса из руки находятся в зависимости CEOpenContainerTest.

Сборка Content.IntegrationTests (DebugOpt, включая Server/Client) этого промежуточного checkout прошла отдельно. Названные тесты запускались в итоговой композиции A–G: 36/36 Passed, без пропусков; это не заявление об отдельном запуске всего набора на каждой промежуточной ветке. Для воспроизведения: собрать Content.IntegrationTests и запустить названную fixture; для итогового игрового сценария нужен контент #430.

## Media

Графические наблюдения относятся к общей проверенной композиции. Новые изображения к этому PR пока не приложены.

## Requirements

- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have tested this pull request and written instructions on how to test it.
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

Опциональный CEConnectedItemSlots. Производство, гнёзда и кормушки не входят в этот PR.
